### PR TITLE
Support for adding Fiducials to the frame

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -796,6 +796,22 @@ class Panel:
             pad.SetSize(pcbnew.wxSize(diameter, diameter))
         self.board.Add(module)
 
+    def addFiducial(self, position, copperDiameter, openingDiameter, bottom=False):
+        """
+        Add fiducial, i.e round copper pad with solder mask opening to the position (`wxPoint`), 
+        with given copperDiameter and openingDiameter. By setting bottom to True, the fiducial
+        is placed on bottom side.
+        """
+        module = pcbnew.PCB_IO().FootprintLoad(KIKIT_LIB, "Fiducial")
+        module.SetPosition(position)
+        if(bottom):
+            module.Flip(position)
+        for pad in module.Pads():
+            pad.SetSize(pcbnew.wxSize(copperDiameter, copperDiameter))
+            pad.SetLocalSolderMaskMargin(int((openingDiameter - copperDiameter) / 2))
+            pad.SetLocalClearance(int((openingDiameter - copperDiameter) / 2))
+        self.board.Add(module)
+    
     def addMillFillets(self, millRadius):
         """
         Add fillets to inner conernes which will be produced a by mill with

--- a/kikit/resources/kikit.pretty/Fiducial.kicad_mod
+++ b/kikit/resources/kikit.pretty/Fiducial.kicad_mod
@@ -1,0 +1,13 @@
+(module Fiducial:Fiducial (layer F.Cu) (tedit 5EA93A7C)
+  (descr "Circular Fiducial")
+  (tags fiducial)
+  (attr smd)
+  (fp_text reference REF** (at 0 -1.5) (layer F.SilkS) hide
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_text value Fiducial (at 0 1.5) (layer F.Fab) hide
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (pad "" smd circle (at 0 0) (size 0.5 0.5) (layers F.Cu F.Mask)
+    (solder_mask_margin 0.25) (clearance 0.25))
+)


### PR DESCRIPTION
Hi and thank you for this excellent tool! This is really a game changer for me.

I needed to add alignment fiducials for pick-and-place to the frame. I thought I'd share it if others find it useful. Allows to adjust the copper diameter and solder mask opening diameter. The function is very similar (read: copy-paste) from the addNPTHole.