### PR TITLE
Frame cuts

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -760,8 +760,20 @@ class Panel:
         outerRect = expandRect(innerAreaExpanded, xDiff, yDiff)
         outerRing = rectToRing(outerRect)
         polygon = Polygon(outerRing, [innerRing])
+        cuts = self.makeFrameCuts( innerArea, innerAreaExpanded, outerRect )
         self.appendSubstrate(polygon)
-        return outerRect
+        return (outerRect, cuts)
+
+    def makeFrameCuts(self, innerArea, innerAreaExpanded, outerArea ):
+        x_coords = [ innerArea.GetX(),
+                     innerArea.GetX() + innerArea.GetWidth() ]
+        y_coords = sorted([ innerAreaExpanded.GetY(),
+                            innerAreaExpanded.GetY() + innerAreaExpanded.GetHeight(), 
+                            outerArea.GetY(),
+                            outerArea.GetY() + outerArea.GetHeight() ])
+        cuts =  [ [(x_coord, y_coords[0]), (x_coord, y_coords[1])] for x_coord in x_coords ]
+        cuts += [ [(x_coord, y_coords[2]), (x_coord, y_coords[3])] for x_coord in x_coords ]
+        return map(LineString, cuts)
 
     def makeVCuts(self, cuts, boundCurves=False):
         """

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -760,11 +760,12 @@ class Panel:
         outerRect = expandRect(innerAreaExpanded, xDiff, yDiff)
         outerRing = rectToRing(outerRect)
         polygon = Polygon(outerRing, [innerRing])
-        cuts = self.makeFrameCuts( innerArea, innerAreaExpanded, outerRect )
+        frame_cuts_v = self.makeFrameCutsV( innerArea, innerAreaExpanded, outerRect )
+        frame_cuts_h = self.makeFrameCutsH( innerArea, innerAreaExpanded, outerRect )
         self.appendSubstrate(polygon)
-        return (outerRect, cuts)
+        return (outerRect, frame_cuts_v, frame_cuts_h)
 
-    def makeFrameCuts(self, innerArea, innerAreaExpanded, outerArea ):
+    def makeFrameCutsV(self, innerArea, innerAreaExpanded, outerArea ):
         x_coords = [ innerArea.GetX(),
                      innerArea.GetX() + innerArea.GetWidth() ]
         y_coords = sorted([ innerAreaExpanded.GetY(),
@@ -773,6 +774,17 @@ class Panel:
                             outerArea.GetY() + outerArea.GetHeight() ])
         cuts =  [ [(x_coord, y_coords[0]), (x_coord, y_coords[1])] for x_coord in x_coords ]
         cuts += [ [(x_coord, y_coords[2]), (x_coord, y_coords[3])] for x_coord in x_coords ]
+        return map(LineString, cuts)
+
+    def makeFrameCutsH(self, innerArea, innerAreaExpanded, outerArea ):
+        y_coords = [ innerArea.GetY(),
+                     innerArea.GetY() + innerArea.GetHeight() ]
+        x_coords = sorted([ innerAreaExpanded.GetX(),
+                            innerAreaExpanded.GetX() + innerAreaExpanded.GetWidth(), 
+                            outerArea.GetX(),
+                            outerArea.GetX() + outerArea.GetWidth() ])
+        cuts =  [ [(x_coords[0], y_coord), (x_coords[1], y_coord)] for y_coord in y_coords ]
+        cuts += [ [(x_coords[2], y_coord), (x_coords[3], y_coord)] for y_coord in y_coords ]
         return map(LineString, cuts)
 
     def makeVCuts(self, cuts, boundCurves=False):

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -749,16 +749,15 @@ class Panel:
         e.g., by `makeGrid`, with given `width` and `height`. Space with width
         `offset` is added around the `innerArea`.
         """
-        innerArea = expandRect(innerArea, offset)
-        innerArea = expandRect(innerArea, -fromMm(0.01))
-        xDiff = (width - innerArea.GetWidth()) // 2
+        innerAreaExpanded = expandRect(innerArea, offset-fromMm(0.01))
+        xDiff = (width - innerAreaExpanded.GetWidth()) // 2
         if xDiff < 0:
             raise RuntimeError("The frame is to small")
-        yDiff = (height - innerArea.GetHeight()) // 2
+        yDiff = (height - innerAreaExpanded.GetHeight()) // 2
         if yDiff < 0:
             raise RuntimeError("The frame is to small")
-        innerRing = rectToRing(innerArea)
-        outerRect = expandRect(innerArea, xDiff, yDiff)
+        innerRing = rectToRing(innerAreaExpanded)
+        outerRect = expandRect(innerAreaExpanded, xDiff, yDiff)
         outerRing = rectToRing(outerRect)
         polygon = Polygon(outerRing, [innerRing])
         self.appendSubstrate(polygon)

--- a/kikit/ui.py
+++ b/kikit/ui.py
@@ -69,9 +69,12 @@ def extractBoard(input, output, sourcearea):
     help="Rename pattern for references. You can use '{n}' for board sequential number and '{orig}' for original reference name")
 @click.option("--tabsfrom", type=(str, float), multiple=True,
     help="Create tabs from lines in given layer. You probably want to specify --vtabs=0 and --htabs=0. Format <layer name> <tab width>")
+@click.option("--framecutV", type=bool, help="Insert vertical cuts through the frame", is_flag=True)
+@click.option("--framecutH", type=bool, help="Insert horizontal cuts through the frame", is_flag=True)
+
 def grid(input, output, space, gridsize, panelsize, tabwidth, tabheight, vcuts,
          mousebites, radius, sourcearea, vcutcurves, htabs, vtabs, rotation,
-         tolerance, renamenet, renameref, tabsfrom):
+         tolerance, renamenet, renameref, tabsfrom, framecutv, framecuth):
     """
     Create a regular panel placed in a frame.
 
@@ -108,12 +111,15 @@ def grid(input, output, space, gridsize, panelsize, tabwidth, tabheight, vcuts,
         panel.appendSubstrate(tabs)
         if vcuts:
             panel.makeVCuts(cuts, vcutcurves)
+        if frame:
+            (_, frame_cuts_v, frame_cuts_h) = panel.makeFrame(psize, fromMm(w), fromMm(h), fromMm(space))
+            if framecutv:
+                cuts += frame_cuts_v
+            if framecuth:
+                cuts += frame_cuts_h
         if mousebites[0]:
             drill, spacing, offset = mousebites
             panel.makeMouseBites(cuts, fromMm(drill), fromMm(spacing), fromMm(offset))
-        if frame:
-            (_, frame_cuts) = panel.makeFrame(psize, fromMm(w), fromMm(h), fromMm(space))
-            cuts += frame_cuts
         panel.addMillFillets(fromMm(radius))
         panel.save(output)
     except Exception as e:

--- a/kikit/ui.py
+++ b/kikit/ui.py
@@ -112,7 +112,8 @@ def grid(input, output, space, gridsize, panelsize, tabwidth, tabheight, vcuts,
             drill, spacing, offset = mousebites
             panel.makeMouseBites(cuts, fromMm(drill), fromMm(spacing), fromMm(offset))
         if frame:
-            panel.makeFrame(psize, fromMm(w), fromMm(h), fromMm(space))
+            (_, frame_cuts) = panel.makeFrame(psize, fromMm(w), fromMm(h), fromMm(space))
+            cuts += frame_cuts
         panel.addMillFillets(fromMm(radius))
         panel.save(output)
     except Exception as e:


### PR DESCRIPTION
I had a need for it, so here's a first cut at #15.  This "works" somewhat for my current case, which is why I rushed it but it leaves a little to be desired. First, here is an example of how this works currently:

![image](https://user-images.githubusercontent.com/192939/82028094-236e0c00-96d0-11ea-8a16-66e1c82ddb53.png)

This might get me through what I need it for now (about to submit for quotes, etc) but seems to have few issues from what I can see.  First, it doesn't generate a real tab like is displayed in #15.  There is no reduction in width of the frame at the tab with a radius.  Second, it seems like either I get drill hits which overlap the edge cuts (like in this picture), or I get too few drill hits in general.  Finally, should this be optional in the CLI?  Should vertical or horizontal cuts be select-able? 