### PR TITLE
Add initial support for JLC PCB assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ KiKit](https://roboticsbrno.github.io/RB0002-BatteryPack).
 - compared to hand-creation of panels, your panels will pass DRC (as tracks from
   different instances of the same board have distinct nets when using KiKit)
 - if you have multiple boards in a single file, you can split them
-- automated export of gerber files
+- [automated export of gerbers and assembly data](doc/fabrication.md)
 - [3D printed self-registering solder paste stencils](doc/stencil.md)
 - [steel stencils with alignment jig](doc/stencil.md)
 

--- a/doc/fabrication.md
+++ b/doc/fabrication.md
@@ -1,0 +1,26 @@
+# Fabrication
+
+KiKit offers fully automatic export of all data required for fabrication of your
+designs. Since every fabrication house has different requirements on the design
+files (e.g., special names of gerber files, different requirements for assembly
+files) there is no "universal exporter" in KiKit. Instead, KiKit offers special
+command for each supported fabrication house.
+
+## Currently Supported:
+
+Note: click on the name of the manufacturer to see corresponding documentation:
+
+- [JLC PCB](fabrication/jlcpcb.md): board manufacturing, SMD assembly. [https://jlcpcb.com/](https://jlcpcb.com/)
+
+## Adding New Fabrication Houses
+
+To add a new fabrication command you have to extend KiKit's source code. A
+rather basic knowledge of python is required to do so.
+
+Create a new file `kikit/fab/fabhousename.py` and implement a new command with
+the same name as the file. Then add the command to `kikit/fab/__init__.py`. The
+common functionality for all fabrication houses should be located in
+`kikit/fab/common.py`. You can use `kikit/fab/jlcpcb.py` for inspiration.
+
+Once you implement a support for new fabrication house, open a pull request on
+KiKit's GitHub page.

--- a/doc/fabrication/jlcpcb.md
+++ b/doc/fabrication/jlcpcb.md
@@ -1,0 +1,70 @@
+# Fabrication: JLC PCB
+
+The basic usage of this exporter is:
+```
+kikit fab jlcpcb [OPTIONS] BOARD OUTPUTDIR
+```
+
+When you run this command, you will find file `gerbers.zip` in `OUTPUTDIR`. This
+file can be directly uploaded to JLC PCB site. KiKit automatically detects the
+number of layers.
+
+## Assembly
+
+If you would also like to use the SMD assembly service, you have to specify
+`--assembly` option and also provide the board `--schematics <schematics_file>`.
+KiKit will generate two extra files: `bom.csv` (bill of materials) and `pos.csv`
+(component placement). Use these two files when ordering the PCB assembly.
+
+The files above will include all components on the board. You can override the
+default field name with option `--field`. You can exclude some of the components
+by specifying `--ignore <comma separated list of references>`. By default, KiKit
+will export only components with SMD footprints (see footprint properties in the
+footprint editor). You can override this by specifying `--forceSMD`: KiKit will
+then include all components that have only SMD pins and will ignore the
+footprint flag. Also, if a component misses the order code field, KiKit will
+show warning. When you pass option `--missingError`, KiKit will fail when there
+is a component with missing order code. This might be useful in case when you
+run KiKit in CI and you want to fail the build.
+
+Note that when you order SMD assembly for a panel, you should specify panelized
+board and the original schematics of a single board.
+
+## Correction of the Footprint Position
+
+It is possible that orientation footprints in your SMD does not match the
+orientation of the components in the SMD assembly service. There are two
+solutions:
+
+- correct the orientation in the library or
+- apply KiKit's orientation corrections.
+
+The first option is not always feasible - e.g., when you use KiCAD's built-in
+libraries or you are preparing a board for multiple fabrication houses and each
+of them uses a different orientation.
+
+KiKit allows you to specify the origin and orientation correction of the
+position. The correction is specified by `JLCPCB_CORRECTION` field. The field
+value is a semicolon separated tuple: `<X>; <Y>; <Rotation>` with values in
+millimeters and degrees. You can read the XY corrections by hovering cursor over
+the intended origin in footprint editor and mark the coordinates. Note that
+first the rotation correction is applied, then the translation. Usually, you
+will need only the rotation correction.
+
+## Using Corrections to Configure Jumpers
+
+If your board features solder jumpers you can use the corrections to specify
+their default value. The solder jumper should be designed such it can fit a zero
+Ohm resistor in suitable size. Then specify an order code of the zero Ohm
+resistor for the jumper and adjust correction so it fits the default position.
+
+Note that you can specify multiple correction fields by `--corrections <comma
+separated list of correction filed names>`. The first found correction field is
+used. This allows you to keep several configuration of the solder jumpers in
+your design e.g., in fields `JLCPCB_CORRECTION_CFG_1` and
+`JLCPCB_CORRECTION_CFG_2`. Then you can simply change the board configuration by
+calling kikit with `--corrections JLCPCB_CORRECTION_CFG_1,JLCPCB_CORRECTION` or
+`--corrections JLCPCB_CORRECTION_CFG_2,JLCPCB_CORRECTION`.
+
+
+

--- a/kikit/common.py
+++ b/kikit/common.py
@@ -117,3 +117,18 @@ def br(rect):
 def bl(rect):
     """ Return bottom left corner of rect """
     return wxPoint(rect.GetX(), rect.GetY() + rect.GetHeight())
+
+def removeComponents(board, references):
+    """
+    Remove components with references from the board. References is a list of
+    strings
+    """
+    for module in board.GetModules():
+        if module.GetReference() in references:
+            board.Remove(module)
+
+def parseReferences(dStr):
+    """
+    Parse comma separated list of component references to a list
+    """
+    return [x.strip() for x in dStr.split(",") if len(x.strip()) > 0]

--- a/kikit/defs.py
+++ b/kikit/defs.py
@@ -42,3 +42,8 @@ class EDA_TEXT_VJUSTIFY_T(IntEnum):
     GR_TEXT_VJUSTIFY_CENTER = 0
     GR_TEXT_VJUSTIFY_BOTTOM = 1
 
+class MODULE_ATTR_T(IntEnum):
+    MOD_DEFAULT = 0,
+    MOD_CMS     = 1
+    MOD_VIRTUAL = 2
+

--- a/kikit/eeshema.py
+++ b/kikit/eeshema.py
@@ -1,0 +1,168 @@
+# Simple, rather hacky parser for eeshema files (.sch). This is a mid-term
+# workaround before proper support for scripting is introduced into Eeschema
+
+import shlex
+import os
+
+class EeschemaException(Exception):
+    pass
+
+def getField(component, field):
+    for f in component["fields"]:
+        n = f["number"]
+        if field == "Reference" and n == 0:
+            return f["text"]
+        if field == "Value" and n == 1:
+            return f["text"]
+        if field == "Footprint" and n == 2:
+            return f["text"]
+        if "name" in f and field == f["name"]:
+            return f["text"]
+    return None
+
+def readEeschemaLine(file):
+    line = file.readline()
+    if not line:
+        raise EeschemaException("Cannot parse EEschema, line expected, got EOF")
+    return line.strip()
+
+def readHeader(file):
+    VERSION_STRING = "EESchema Schematic File Version"
+    DESCR_STRING = "$Descr "
+    header = {}
+    while True:
+        line = readEeschemaLine(file)
+        if line == "$EndDescr":
+            return header
+
+        if line.startswith(VERSION_STRING):
+            header["version"] = line[len(VERSION_STRING):].strip()
+        elif line.startswith("LIBS:"):
+            header["libs"] = header.get("libs", []) + [line[len("LIBS:"):].strip()]
+        elif line.startswith("EELAYER"):
+            pass
+        elif line.startswith(DESCR_STRING):
+            header["size"] = line[len(DESCR_STRING):].split()
+        elif line.startswith("Sheet"):
+            items = line.split(maxsplit=3)
+            header["sheet"] = (int(items[1]), int(items[2]))
+        elif line.startswith("Title"):
+            header["title"] = line.split(maxsplit=2)[1]
+        elif line.startswith("Date"):
+            header["date"] = line.split(maxsplit=2)[1]
+        elif line.startswith("Comp"):
+            header["company"] = line.split(maxsplit=2)[1]
+        elif line.startswith("Rev"):
+            header["revision"] = line.split(maxsplit=2)[1]
+        elif line.startswith("Comment1"):
+            header["comment1"] = line.split(maxsplit=2)[1]
+        elif line.startswith("Comment2"):
+            header["comment2"] = line.split(maxsplit=2)[1]
+        elif line.startswith("Comment3"):
+            header["comment3"] = line.split(maxsplit=2)[1]
+        elif line.startswith("Comment4"):
+            header["comment4"] = line.split(maxsplit=2)[1]
+        elif line.startswith("encoding"):
+            header["encoding"] = line.split(maxsplit=2)[1]
+        else:
+            raise EeschemaException(f"Unexpected line: '{line}'")
+
+def readComponent(file, sheetPath=""):
+    component = {}
+    while True:
+        line = readEeschemaLine(file)
+        if line == "$EndComp":
+            return component
+
+        if line.startswith("L"):
+            items = line.split()
+            component["reference"] = items[2]
+            component["name"] = items[1]
+        elif line.startswith("U"):
+            items = line.split()
+            component["u"] = items[3]
+            component["unit"] = int(items[1])
+        elif line.startswith("P"):
+            items = line.split()
+            component["position"] = (int(items[1]), int(items[2]))
+        elif line.startswith("F"):
+            items = shlex.split(line)
+            field = {
+                "number": int(items[1]),
+                "text": items[2],
+                "orientation": items[3],
+                "position": (int(items[4]), int(items[5])),
+                "size": items[6],
+                "flags": items[7],
+                "justify": items[8],
+                "style": items[9]
+            }
+            if field["number"] >= 4:
+                field["name"] = items[10]
+            component["fields"] = component.get("fields", []) + [field]
+        elif line.startswith("AR"):
+            # Hierarchical sheet reference. We assume all sheets are used within
+            # the project, therefore we do not check validity of path
+            items = shlex.split(line)
+            path = None
+            ref = None
+            for item in items:
+                if item.startswith('Path='):
+                    path = item[len('Path='):]
+                    break
+            for item in items:
+                if item.startswith('Ref='):
+                    ref = item[len('Ref='):]
+                    break
+            if path is not None and ref is not None:
+                compPath = sheetPath + "/" + component["u"]
+                if path == compPath:
+                    component["reference"] = ref
+        else:
+            items = shlex.split(line)
+            try:
+                int(items[0])
+                if len(items) == 3 and items[0] == "1":
+                    # Duplicate position entry
+                    pass
+                if len(items) == 4:
+                    component["orientation"] = [int(x) for x in items[1:]]
+            except ValueError:
+                raise EeschemaException(f"Unexpected line: '{line}'")
+
+def readSheet(file):
+    # Note that the parser is incomplete an only extracts filename and reference
+    # from the sheet as it is all we need currently
+    sheet = {}
+    while True:
+        line = readEeschemaLine(file)
+        if line == "$EndSheet":
+            return sheet
+        if line.startswith("F1 "):
+            items = shlex.split(line)
+            sheet["f1"] = items[1]
+        elif line.startswith("U "):
+            sheet["u"] = line.split()[1]
+
+def extractComponents(filename, path=""):
+    """
+    Extract all components from the schematics
+    """
+    components = []
+    sheets = []
+    with open(filename, "r", encoding="utf-8") as file:
+        header = readHeader(file)
+        while True:
+            line = file.readline()
+            if not line:
+                break
+            line = line.strip()
+            if line.startswith("$Comp"):
+                components.append(readComponent(file, path))
+            if line.startswith("$Sheet"):
+                sheets.append(readSheet(file))
+    for s in sheets:
+        dirname = os.path.dirname(filename)
+        sheetfilename = os.path.join(dirname, s["f1"])
+        components += extractComponents(sheetfilename, path + "/" + s["u"])
+    return components

--- a/kikit/fab/__init__.py
+++ b/kikit/fab/__init__.py
@@ -1,0 +1,12 @@
+import click
+from kikit.fab.jlcpcb import jlcpcb
+
+
+@click.group()
+def fab():
+    """
+    Export complete manufacturing data for given fabrication houses
+    """
+    pass
+
+fab.add_command(jlcpcb)

--- a/kikit/fab/common.py
+++ b/kikit/fab/common.py
@@ -1,0 +1,8 @@
+import pcbnew
+
+
+def hasNonSMDPins(module):
+    for pad in module.Pads():
+        if pad.GetAttribute() != pcbnew.PAD_ATTRIB_SMD:
+            return True
+    return False

--- a/kikit/fab/jlcpcb.py
+++ b/kikit/fab/jlcpcb.py
@@ -1,0 +1,170 @@
+import click
+import pcbnew
+import csv
+import os
+import sys
+import shutil
+from math import sin, cos, radians
+from pathlib import Path
+from kikit.eeshema import extractComponents, getField
+from kikit.defs import MODULE_ATTR_T
+from kikit.fab.common import hasNonSMDPins
+from kikit.common import *
+from kikit.export import gerberImpl
+
+class FormatError(Exception):
+    pass
+
+def layerToSide(layer):
+    if layer == pcbnew.F_Cu:
+        return "T"
+    if layer == pcbnew.B_Cu:
+        return "B"
+    raise RuntimeError(f"Got component with invalid layer {layer}")
+
+def modulePosition(module, placeOffset, compensation):
+    pos = module.GetPosition() - placeOffset
+    angle = -radians(module.GetOrientation() / 10.0)
+    x = compensation[0] * cos(angle) - compensation[1] * sin(angle)
+    y = compensation[0] * sin(angle) + compensation[1] * cos(angle)
+    pos += wxPoint(fromMm(x), fromMm(y))
+    return pos
+
+def moduleX(module, placeOffset, compensation):
+    pos = modulePosition(module, placeOffset, compensation)
+    if module.GetLayer() == pcbnew.B_Cu:
+        return -toMm(pos[0])
+    return toMm(pos[0])
+
+def moduleY(module, placeOffset, compensation):
+    return -toMm(modulePosition(module, placeOffset, compensation)[1])
+
+def moduleOrientation(module, compensation):
+    return module.GetOrientation() / 10 + compensation[2]
+
+def parseCompensation(compensation):
+    comps = [float(x) for x in compensation.split(";")]
+    if len(comps) != 3:
+        raise FormatError(f"Invalid format of compensation '{compensation}'")
+    return comps
+
+def collectPosData(board, correctionFields=["JLCPCB_CORRECTION"], bom=None,
+                   forceSmd=False):
+    """
+    Extract position data of the modules.
+
+    If the optional BOM contains fields "JLCPCB_CORRECTION" in format
+    '<X>;<Y>;<ROTATION>' these corrections of component origin and rotation are
+    added to the position (in millimeters and degrees). Read the XY corrections
+    by hovering cursor over the intended origin in footprint editor and mark the
+    coordinates.
+    """
+    if bom is None:
+        bom = {}
+    else:
+        bom = { comp["reference"]: comp for comp in bom }
+    modules = []
+    placeOffset = board.GetDesignSettings().m_AuxOrigin
+    for module in board.GetModules():
+        if module.GetAttributes() & MODULE_ATTR_T.MOD_VIRTUAL:
+            continue
+        # We can use module.HasNonSMDPins() in KiCAD 6
+        if module.GetAttributes() & MODULE_ATTR_T.MOD_CMS or (forceSmd and not hasNonSMDPins(module)):
+            modules.append(module)
+    def getCompensation(module):
+        if module.GetReference() not in bom:
+            return 0, 0, 0
+        field = None
+        for fieldName in correctionFields:
+            field = getField(bom[module.GetReference()], fieldName)
+            if field is not None:
+                break
+        if field is None:
+            return 0, 0, 0
+        try:
+            return parseCompensation(field)
+        except FormatError as e:
+            raise FormatError(f"{module.GetReference()}: {e}")
+    return [(module.GetReference(),
+             moduleX(module, placeOffset, getCompensation(module)),
+             moduleY(module, placeOffset, getCompensation(module)),
+             layerToSide(module.GetLayer()),
+             moduleOrientation(module, getCompensation(module))) for module in modules]
+
+def collectBom(components, lscsField):
+    bom = {}
+    for c in components:
+        if c["unit"] != 1:
+            continue
+        reference = c["reference"]
+        if reference.startswith("#PWR") or reference.startswith("#FL"):
+            continue
+        cType = (
+            getField(c, "Value"),
+            getField(c, "Footprint"),
+            getField(c, lscsField)
+        )
+        bom[cType] = bom.get(cType, []) + [reference]
+    return bom
+
+def posDataToFile(posData, filename):
+    with open(filename, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["Designator", "Mid X", "Mid Y", "Layer", "Rotation"])
+        for line in sorted(posData, key=lambda x: x[0]):
+            writer.writerow(line)
+
+def bomToCsv(bomData, filename):
+    with open(filename, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["Comment", "Designator", "Footprint", "LCSC"])
+        for cType, references in bomData.items():
+            value, footprint, lcsc = cType
+            writer.writerow([value, ",".join(references), footprint, lcsc])
+
+@click.command()
+@click.argument("board", type=click.Path(dir_okay=False))
+@click.argument("outputdir", type=click.Path(file_okay=False))
+@click.option("--assembly/--no-assembly", help="Generate files for SMT assembly (schematics is required)")
+@click.option("--schematic", type=click.Path(dir_okay=False), help="Board schematics (required for assembly files)")
+@click.option("--forceSMD", is_flag=True, help="Force include all components having only SMD pads")
+@click.option("--ignore", type=str, default="", help="Comma separated list of designators to exclude from SMT assembly")
+@click.option("--field", type=str, default="LCSC", help="Name of component field with LCSC order code")
+@click.option("--corrections", type=str, default="JLCPCB_CORRECTION",
+    help="Comma separated list of component fields with the correction value. First existing field is used")
+@click.option("--missingError/--missingWarn", help="If a non-ignored component misses LCSC field, fail")
+def jlcpcb(board, outputdir, assembly, schematic, forcesmd, ignore, field,
+           corrections, missingerror):
+    """
+    Prepare fabrication files for JLCPCB including their assembly service
+    """
+    loadedBoard = pcbnew.LoadBoard(board)
+    refs = parseReferences(ignore)
+    removeComponents(loadedBoard, refs)
+    Path(outputdir).mkdir(parents=True, exist_ok=True)
+
+    gerberdir = os.path.join(outputdir, "gerber")
+    shutil.rmtree(gerberdir, ignore_errors=True)
+    gerberImpl(board, gerberdir)
+    shutil.make_archive(os.path.join(outputdir, "gerbers"), "zip", outputdir, "gerber")
+
+    if not assembly:
+        return
+    if schematic is None:
+        raise RuntimeError("When outputing assembly data, schematic is required")
+    correctionFields = [x.strip() for x in corrections.split(",")]
+    components = extractComponents(schematic)
+    bom = collectBom(components, field)
+
+    missingFields = False
+    for type, references in bom.items():
+        _, _, lcsc = type
+        if not lcsc:
+            missingFields = True
+            for r in references:
+                print(f"WARNING: Component {r} is missing ordercode")
+    if missingFields and missingerror:
+        sys.exit("There are components with missing ordercode, aborting")
+
+    posDataToFile(collectPosData(loadedBoard, correctionFields, components, forcesmd), os.path.join(outputdir, "pos.csv"))
+    bomToCsv(bom, os.path.join(outputdir, "bom.csv"))

--- a/kikit/stencil.py
+++ b/kikit/stencil.py
@@ -8,6 +8,7 @@ from kikit.export import gerberImpl, pasteDxfExport
 import solid
 import solid.utils
 import subprocess
+from kikit.common import removeComponents, parseReferences
 
 from shapely.geometry import Point
 
@@ -266,22 +267,6 @@ def renderScad(infile, outfile):
     infile = os.path.abspath(infile)
     outfile = os.path.abspath(outfile)
     subprocess.check_call(["openscad", "-o", outfile, infile])
-
-
-def removeComponents(board, references):
-    """
-    Remove components with references from the board. References is a list of
-    strings
-    """
-    for module in board.GetModules():
-        if module.GetReference() in references:
-            board.Remove(module)
-
-def parseReferences(dStr):
-    """
-    Parse comma separated list of component references to a list
-    """
-    return [x.strip() for x in dStr.split(",") if len(x.strip()) > 0]
 
 
 from pathlib import Path

--- a/kikit/ui.py
+++ b/kikit/ui.py
@@ -4,6 +4,7 @@ from kikit.panelize import Panel, fromMm, wxPointMM, wxRectMM, fromDegrees
 from kikit.present import boardpage
 from kikit.modify import references
 from kikit.stencil import stencil
+from kikit.fab import fab
 from kikit import __version__
 import sys
 
@@ -260,7 +261,7 @@ cli.add_command(panelize)
 cli.add_command(present)
 cli.add_command(modify)
 cli.add_command(stencil)
-
+cli.add_command(fab)
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
Both BOM and POS files are pretty easy to implement, therefore, it makes sense not to wait for Python API and implement the logic in KiKit. To get the BOM file, we need to parse the schematic file, which is currently pretty easy to do (and when we switch to KiCAD 6, we use Eeschema Python API to generate it)

I am looking for testers before I merge this functionality into master. If you are interested in testing, install development version of KiKit by:
```
pip3 install git+https://github.com/yaqwsx/KiKit@fabrication
```

The usage should be pretty straightforward (but currently lacks documentation). Just run `kikit fab jlcpcb --help`. KiKit expects there is a field "LSCS" with LSCS number in for the components in schematics.

Please, report both working and not working cases.