### PR TITLE
Add openscad to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       kicad kicad-libraries zip inkscape make git libmagickwand-dev \
       python3 python3-pip python3-wheel python3-setuptools inkscape \
-      libgraphicsmagick1-dev libmagickcore-dev
+      libgraphicsmagick1-dev libmagickcore-dev openscad
 
 RUN pip3 install Pcbdraw KiKit
 


### PR DESCRIPTION
When trying to generate a stencil via Docker, it fails because openscad is not available in the container.

Error is: `FileNotFoundError: [Errno 2] No such file or directory: 'openscad': 'openscad'`