### PR TITLE
Fix Flip in addFiducial

### DIFF
--- a/kikit/export.py
+++ b/kikit/export.py
@@ -2,6 +2,7 @@
 import sys
 import os
 from pcbnew import *
+from kikit import pcbnew_compatibility
 
 fullGerberPlotPlan = [
     # name, id, comment
@@ -44,7 +45,7 @@ def gerberImpl(boardfile, outputdir, plot_plan=fullGerberPlotPlan, drilling=True
     popt.SetOutputDirectory(plotDir)
 
     popt.SetPlotFrameRef(False)
-    popt.SetLineWidth(FromMM(0.35))
+    popt.SetSketchPadLineWidth(FromMM(0.35))
     popt.SetAutoScale(False)
     popt.SetScale(1)
     popt.SetMirror(False)

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -820,7 +820,10 @@ class Panel:
         module = pcbnew.PCB_IO().FootprintLoad(KIKIT_LIB, "Fiducial")
         module.SetPosition(position)
         if(bottom):
-            module.Flip(position)
+            if pcbnew_compatibility.isV6(pcbnew_compatibility.pcbnewVersion):
+                module.Flip(position, False)
+            else:
+                module.Flip(position)
         for pad in module.Pads():
             pad.SetSize(pcbnew.wxSize(copperDiameter, copperDiameter))
             pad.SetLocalSolderMaskMargin(int((openingDiameter - copperDiameter) / 2))

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -378,7 +378,7 @@ class Panel:
     def _setVCutLabelStyle(self, label, layer):
         label.SetText("V-CUT")
         label.SetLayer(layer)
-        label.SetThickness(fromMm(0.4))
+        label.SetTextThickness(fromMm(0.4))
         label.SetTextSize(pcbnew.wxSizeMM(2, 2))
         label.SetHorizJustify(EDA_TEXT_HJUSTIFY_T.GR_TEXT_HJUSTIFY_LEFT)
 

--- a/kikit/pcbnew_compatibility.py
+++ b/kikit/pcbnew_compatibility.py
@@ -24,3 +24,4 @@ if not isV6(pcbnewVersion):
     pcbnew.FP_SHAPE = pcbnew.EDGE_MODULE
     pcbnew.PCB_TEXT = pcbnew.TEXTE_PCB
     pcbnew.FP_TEXT = pcbnew.TEXTE_MODULE
+    pcbnew.PCB_PLOT_PARAMS.SetSketchPadLineWidth = pcbnew.PCB_PLOT_PARAMS.SetLineWidth

--- a/kikit/pcbnew_compatibility.py
+++ b/kikit/pcbnew_compatibility.py
@@ -25,3 +25,4 @@ if not isV6(pcbnewVersion):
     pcbnew.PCB_TEXT = pcbnew.TEXTE_PCB
     pcbnew.FP_TEXT = pcbnew.TEXTE_MODULE
     pcbnew.PCB_PLOT_PARAMS.SetSketchPadLineWidth = pcbnew.PCB_PLOT_PARAMS.SetLineWidth
+    pcbnew.PCB_TEXT.SetTextThickness = pcbnew.PCB_TEXT.SetThickness


### PR DESCRIPTION
In Kicad 6 `Flip` requires a positional argument (aFlipLeftRight).
Set FlipLeftRight to `False` since it is symmetrical.