### PR TITLE
Implement DRC rules inheritance & DRC checking

### DIFF
--- a/kikit/drc.py
+++ b/kikit/drc.py
@@ -1,0 +1,18 @@
+from kikit.pcbnew_compatibility import pcbnew, isV6, getVersion
+import sys
+import tempfile
+
+def runImpl(boardfile, useMm, strict):
+    try:
+        if not isV6(getVersion()):
+            raise RuntimeError("This feature is available only with KiCAD 6.")
+        units = pcbnew.EDA_UNITS_MILLIMETRES if useMm else EDA_UNITS_INCHES
+        b = pcbnew.LoadBoard(boardfile)
+        with tempfile.NamedTemporaryFile(mode="w+") as tmpFile:
+            result = pcbnew.WriteDRCReport(b, tmpFile.name, units, strict)
+            tmpFile.seek(0)
+            print(tmpFile.read())
+            sys.exit(result)
+    except Exception as e:
+        sys.stderr.write("An error occurred: " + str(e) + "\n")
+        sys.exit(1)

--- a/kikit/drc_ui.py
+++ b/kikit/drc_ui.py
@@ -1,0 +1,25 @@
+import click
+
+@click.group()
+def drc():
+    """
+    Validate design rules of the board
+    """
+    pass
+
+@click.command()
+@click.argument("boardfile", type=click.Path(dir_okay=False))
+@click.option("--useMm/--useInch", default=True)
+@click.option("--strict/--weak", default=False,
+    help="Check all track errors")
+def run(boardfile, usemm, strict):
+    """
+    Check DRC rules. If no rules are validated, the process exists with code 0.
+
+    If any errors are detected, the process exists with non-zero return code and
+    prints DRC report on the standard output.
+    """
+    from kikit.drc import runImpl
+    runImpl(boardfile, usemm, strict)
+
+drc.add_command(run)

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -948,7 +948,7 @@ class Panel:
             raise RuntimeError("The substrate has to be a single piece to fill unused areas")
         increaseZonePriorities(self.board)
 
-        zoneContainer = pcbnew.ZONE_CONTAINER(self.board)
+        zoneContainer = pcbnew.ZONES(self.board)
         boundary = self.boardSubstrate.exterior().boundary
         zoneContainer.Outline().AddOutline(linestringToKicad(boundary))
         for substrate in self.substrates:

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -260,6 +260,32 @@ class Panel:
     def _uniquePrefix(self):
         return "Board_{}-".format(self.boardCounter)
 
+    def inheritDesignSettings(self, boardFilename):
+        """
+        Inherit design settings from the given board specified by a filename
+        """
+        b = pcbnew.LoadBoard(boardFilename)
+        self.setDesignSettings(b.GetDesignSettings())
+
+    def setDesignSettings(self, designSettings):
+        """
+        Set design settings
+        """
+        self.board.SetDesignSettings(designSettings)
+
+    def inheritProperties(self, boardFilename):
+        """
+        Inherit text properties from a board specified by a properties
+        """
+        b = pcbnew.LoadBoard(boardFilename)
+        self.setDesignSettings(b.GetDesignSettings())
+
+    def setProperties(self, properties):
+        """
+        Set text properties cached in the board
+        """
+        self.board.SetProperties(designSettings)
+
     def appendBoard(self, filename, destination, sourceArea=None,
                     origin=Origin.Center, rotationAngle=0, shrink=False,
                     tolerance=0, bufferOutline=fromMm(0.001), netRenamer=None,

--- a/kikit/panelize_ui.py
+++ b/kikit/panelize_ui.py
@@ -31,6 +31,8 @@ def extractBoard(input, output, sourcearea):
         panel = Panel()
         destination = wxPointMM(150, 100)
         area = wxRectMM(*sourcearea)
+        panel.inheritDesignSettings(input)
+        panel.inheritProperties(input)
         panel.appendBoard(input, destination, area, tolerance=fromMm(2))
         panel.save(output)
     except Exception as e:
@@ -95,6 +97,8 @@ def grid(input, output, space, gridsize, panelsize, tabwidth, tabheight, vcuts,
     import sys
     try:
         panel = Panel()
+        panel.inheritDesignSettings(input)
+        panel.inheritProperties(input)
         rows, cols = gridsize
         if rows == -1 or cols == -1:
             raise RuntimeError("Gridsize is mandatory. Please specify the --gridsize option.")
@@ -213,6 +217,8 @@ def tightgrid(input, output, space, gridsize, panelsize, tabwidth, tabheight, vc
     import sys
     try:
         panel = Panel()
+        panel.inheritDesignSettings(input)
+        panel.inheritProperties(input)
         rows, cols = gridsize
         if rows == -1 or cols == -1:
             raise RuntimeError("Gridsize is mandatory. Please specify the --gridsize option.")

--- a/kikit/pcbnew_compatibility.py
+++ b/kikit/pcbnew_compatibility.py
@@ -32,6 +32,7 @@ if not isV6(pcbnewVersion):
     pcbnew.FP_TEXT = pcbnew.TEXTE_MODULE
     pcbnew.PCB_PLOT_PARAMS.SetSketchPadLineWidth = pcbnew.PCB_PLOT_PARAMS.SetLineWidth
     pcbnew.PCB_TEXT.SetTextThickness = pcbnew.PCB_TEXT.SetThickness
+    pcbnew.ZONES = pcbnew.ZONE_CONTAINER
 
     # Add board properties
     pcbnew.BOARD.GetProperties = boardGetProperties

--- a/kikit/pcbnew_compatibility.py
+++ b/kikit/pcbnew_compatibility.py
@@ -11,6 +11,12 @@ def getVersion():
         # KiCAD 5 does not have such function, assume it version 5.something
         return 5, 0
 
+def boardGetProperties(self):
+    return {}
+
+def boardSetProperties(self, p):
+    pass
+
 def isV6(version):
     if version[0] == 5 and version[1] == 99:
         return True
@@ -26,3 +32,7 @@ if not isV6(pcbnewVersion):
     pcbnew.FP_TEXT = pcbnew.TEXTE_MODULE
     pcbnew.PCB_PLOT_PARAMS.SetSketchPadLineWidth = pcbnew.PCB_PLOT_PARAMS.SetLineWidth
     pcbnew.PCB_TEXT.SetTextThickness = pcbnew.PCB_TEXT.SetThickness
+
+    # Add board properties
+    pcbnew.BOARD.GetProperties = boardGetProperties
+    pcbnew.BOARD.SetProperties = boardSetProperties

--- a/kikit/ui.py
+++ b/kikit/ui.py
@@ -1,5 +1,6 @@
 import click
-from kikit import panelize_ui, export_ui, present_ui, stencil_ui, modify_ui, fab_ui
+from kikit import (panelize_ui, export_ui, present_ui, stencil_ui,
+    modify_ui, fab_ui, drc_ui)
 from kikit import __version__
 import sys
 
@@ -14,6 +15,7 @@ cli.add_command(present_ui.present)
 cli.add_command(modify_ui.modify)
 cli.add_command(stencil_ui.stencil)
 cli.add_command(fab_ui.fab)
+cli.add_command(drc_ui.drc)
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
Unfortunately, the DRC API that landed in v5.99 is rather poor: https://gitlab.com/kicad/code/kicad/-/commit/8f01771138fd2517b1cb0fce9b13c20e32de5cd8

(Un)fortunately, that means 2 things:
- all that is needed to implement design rules inheritance is to copy the corresponding structure
- we can perform rules checking from CLI (with limited options for now)

In the future, we could implement a parser of the output and provide additional details (e.g., save board images?) Not sure.

Nevertheless, this PR is WIP as the DRC is crashing with current nightly on assert violation.

This addresses #36
