### PR TITLE
Modulo 360 footprint orientation after correction

### DIFF
--- a/kikit/fab/common.py
+++ b/kikit/fab/common.py
@@ -31,7 +31,7 @@ def footprintPosition(footprint, placeOffset, compensation):
     return pos
 
 def footprintOrientation(footprint, compensation):
-    return footprint.GetOrientation() / 10 + compensation[2]
+    return (footprint.GetOrientation() / 10 + compensation[2]) % 360
 
 def parseCompensation(compensation):
     comps = [float(x) for x in compensation.split(";")]


### PR DESCRIPTION
Take the current result of corrected footprint orientation and modulo 360 it.

This prevents the output value being outside the sensible range of one full rotation.

Please let me know if I have overlooked some use case for multiple rotations. I can only think of issues it could cause but maybe someone else has another idea?