### PR TITLE
Changed stencil create function to omit the Edge.Cuts layer

### DIFF
--- a/kikit/stencil.py
+++ b/kikit/stencil.py
@@ -5,7 +5,7 @@ from kikit.common import *
 from kikit.defs import *
 from kikit.substrate import Substrate, extractRings, toShapely, linestringToKicad
 from kikit.export import gerberImpl, pasteDxfExport
-from kikit.export import exportSettingsJlcpcb as exportSettings
+from kikit.export import exportSettingsJlcpcb
 import solid
 import solid.utils
 import subprocess
@@ -312,6 +312,9 @@ def create(inputboard, outputdir, jigsize, jigthickness, pcbthickness,
         ("PasteBottom", pcbnew.B_Paste, "Paste Bottom"),
         ("PasteTop", pcbnew.F_Paste, "Paste top"),
     ]
+    # get a copy of exportSettingsJlcpcb dictionary and
+    # exclude the Edge.Cuts layer for creation of stencil gerber files
+    exportSettings = exportSettingsJlcpcb.copy()
     exportSettings["ExcludeEdgeLayer"] = True
     gerberDir = os.path.join(outputdir, "gerber")
     gerberImpl(stencilFile, gerberDir, plotPlan, False, exportSettings)

--- a/kikit/stencil.py
+++ b/kikit/stencil.py
@@ -5,6 +5,7 @@ from kikit.common import *
 from kikit.defs import *
 from kikit.substrate import Substrate, extractRings, toShapely, linestringToKicad
 from kikit.export import gerberImpl, pasteDxfExport
+from kikit.export import exportSettingsJlcpcb as exportSettings
 import solid
 import solid.utils
 import subprocess
@@ -311,8 +312,9 @@ def create(inputboard, outputdir, jigsize, jigthickness, pcbthickness,
         ("PasteBottom", pcbnew.B_Paste, "Paste Bottom"),
         ("PasteTop", pcbnew.F_Paste, "Paste top"),
     ]
+    exportSettings["ExcludeEdgeLayer"] = True
     gerberDir = os.path.join(outputdir, "gerber")
-    gerberImpl(stencilFile, gerberDir, plotPlan, False)
+    gerberImpl(stencilFile, gerberDir, plotPlan, False, exportSettings)
     gerbers = [os.path.join(gerberDir, x) for x in os.listdir(gerberDir)]
     subprocess.check_call(["zip", "-j",
         os.path.join(outputdir, "gerbers.zip")] + gerbers)


### PR DESCRIPTION
When creating the stencil, it seems that the Edge.Cuts layer is used as well. Tested with KiCad 5.1.9
Not sure if this is a deliberate functionality or a bug, but makes no sense as I see it.

![kikit_stencil_issue_marked](https://user-images.githubusercontent.com/54531717/107655280-b352dd80-6c83-11eb-892f-3484893d2d63.png)

The change made here simply fetches the default dictionary used for the export settings from _export.py_ (which would be used anyway as default in _gerberImpl_) and sets the _ExcludeEdgeLayer_ entry only for the _create_ function in _stencil.py_ to remove the edge layer. 

![kikit_stencil_fixed](https://user-images.githubusercontent.com/54531717/107655295-b8179180-6c83-11eb-8a35-05c56da395c4.png)