### PR TITLE
Implement support for footprint correction patterns

### DIFF
--- a/kikit/fab/common.py
+++ b/kikit/fab/common.py
@@ -144,10 +144,13 @@ def readCorrectionPatterns(filename):
     return correctionPatterns
 
 def applyCorrectionPattern(correctionPatterns, footprint):
-    footprintName = str(footprint.GetFPID().GetLibItemName())
-    for pattern, value in correctionPatterns.items():
-        if pattern.match(footprintName):
-            return value
+    # FIXME: part ID is currently ignored
+    # GetUniStringLibId returns the full footprint name including the 
+    # library in the form of "Resistor_SMD:R_0402_1005Metric"
+    footprintName = str(footprint.GetFPID().GetUniStringLibId())
+    for corpat in correctionPatterns:
+        if corpat.footprint.match(footprintName):
+            return (corpat.x_correction, corpat.y_correction, corpat.rotation)
     return (0, 0, 0)
 
 def collectPosData(board, correctionFields, posFilter=lambda x : True,

--- a/kikit/fab/common.py
+++ b/kikit/fab/common.py
@@ -1,4 +1,6 @@
 import csv
+import re
+from typing import OrderedDict
 from pcbnewTransition import pcbnew, isV6
 from math import sin, cos, radians
 from kikit.common import *
@@ -96,8 +98,42 @@ def excludeFromPos(footprint):
     else:
         return footprint.GetAttributes() & MODULE_ATTR_T.MOD_VIRTUAL
 
+def readCorrectionPatterns(filename):
+    """
+    Read footprint correction pattern file.
+
+    The file should be a CSV file with the following fields:
+    - Regexp to match to the footprint
+    - X correction
+    - Y correction
+    - Rotation
+    """
+    corrections = OrderedDict()
+    with open(filename) as csvfile:
+        sample = csvfile.read(1024)
+        dialect = csv.Sniffer().sniff(sample)
+        has_header = csv.Sniffer().has_header(sample)
+        csvfile.seek(0)
+        reader = csv.reader(csvfile, dialect)
+        first = True
+        for row in reader:
+            if has_header and first:
+                first = False
+                continue
+            corrections[re.compile(row[0])] = (
+                float(row[1]), float(row[2]), float(row[3]))
+    return corrections
+
+def applyCorrectionPattern(correctionPatterns, footprint):
+    footprintName = str(footprint.GetFPID().GetLibItemName())
+    for pattern, value in correctionPatterns.items():
+        if pattern.match(footprintName):
+            return value
+    return (0, 0, 0)
+
 def collectPosData(board, correctionFields, posFilter=lambda x : True,
-                   footprintX=defaultFootprintX, footprintY=defaultFootprintY, bom=None):
+                   footprintX=defaultFootprintX, footprintY=defaultFootprintY, bom=None,
+                   correctionFile=None):
     """
     Extract position data of the footprints.
 
@@ -111,6 +147,11 @@ def collectPosData(board, correctionFields, posFilter=lambda x : True,
         bom = {}
     else:
         bom = { getReference(comp): comp for comp in bom }
+
+    correctionPatterns = {}
+    if correctionFile is not None:
+        correctionPatterns = readCorrectionPatterns(correctionFile)
+
     footprints = []
     placeOffset = board.GetDesignSettings().GetAuxOrigin()
     for footprint in board.GetFootprints():
@@ -127,7 +168,9 @@ def collectPosData(board, correctionFields, posFilter=lambda x : True,
             if field is not None:
                 break
         if field is None or field == "":
-            return 0, 0, 0
+            return applyCorrectionPattern(
+                correctionPatterns,
+                footprint)
         try:
             return parseCompensation(field)
         except FormatError as e:

--- a/kikit/fab/jlcpcb.py
+++ b/kikit/fab/jlcpcb.py
@@ -46,7 +46,7 @@ def noFilter(footprint):
     return True
 
 def exportJlcpcb(board, outputdir, assembly, schematic, ignore, field,
-           corrections, missingerror, nametemplate, drc):
+           corrections, correctionpatterns, missingerror, nametemplate, drc):
     """
     Prepare fabrication files for JLCPCB including their assembly service
     """
@@ -75,7 +75,7 @@ def exportJlcpcb(board, outputdir, assembly, schematic, ignore, field,
     bom = collectBom(components, ordercodeFields, refsToIgnore)
 
     posData = collectPosData(loadedBoard, correctionFields,
-        bom=components, posFilter=noFilter)
+        bom=components, posFilter=noFilter, correctionFile=correctionpatterns)
     boardReferences = set([x[0] for x in posData])
     bom = {key: [v for v in val if v in boardReferences] for key, val in bom.items()}
     bom = {key: val for key, val in bom.items() if len(val) > 0}

--- a/kikit/fab/pcbway.py
+++ b/kikit/fab/pcbway.py
@@ -118,7 +118,7 @@ def bomToCsv(bomData, filename, nBoards, types):
 
 def exportPcbway(board, outputdir, assembly, schematic, ignore,
                  manufacturer, partnumber, description, notes, soldertype,
-                 footprint, corrections, missingerror, nboards, nametemplate, drc):
+                 footprint, corrections, correctionpatterns, missingerror, nboards, nametemplate, drc):
     """
     Prepare fabrication files for PCBWay including their assembly service
     """
@@ -164,7 +164,7 @@ def exportPcbway(board, outputdir, assembly, schematic, ignore,
     if missingFields and missingerror:
         sys.exit("There are components with missing ordercode, aborting")
 
-    posData = collectPosData(loadedBoard, correctionFields, bom=components)
+    posData = collectPosData(loadedBoard, correctionFields, bom=components, correctionFile=correctionpatterns)
     posDataToFile(posData, os.path.join(outputdir, nametemplate.format("pos") + ".csv"))
     types = collectSolderTypes(loadedBoard)
     bomToCsv(bom, os.path.join(outputdir, nametemplate.format("bom") + ".csv"), nboards, types)

--- a/kikit/fab_ui.py
+++ b/kikit/fab_ui.py
@@ -23,6 +23,7 @@ def fabCommand(f):
     help="Comma separated list of component fields field with LCSC order code. First existing field is used")
 @click.option("--corrections", type=str, default="JLCPCB_CORRECTION",
     help="Comma separated list of component fields with the correction value. First existing field is used")
+@click.option("--correctionpatterns", type=click.Path(dir_okay=False))
 @click.option("--missingError/--missingWarn", help="If a non-ignored component misses LCSC field, fail")
 def jlcpcb(**kwargs):
     """
@@ -48,6 +49,7 @@ def jlcpcb(**kwargs):
 @click.option("--ignore", type=str, default="", help="Comma separated list of designators to exclude from SMT assembly")
 @click.option("--corrections", type=str, default="PCBWAY_CORRECTION",
     help="Comma separated list of component fields with the correction value. First existing field is used")
+@click.option("--correctionpatterns", type=click.Path(dir_okay=False))
 @click.option("--manufacturer", type=str, default="Manufacturer",
     help="Comma separated list of fields to extract manufacturer name from. First existing field is used.")
 @click.option("--partNumber", type=str, default="PartNumber",


### PR DESCRIPTION
In reference to my comments on Issue #115, I decided to provide a PR for review after all.

As discussed in the issue, the approach of correcting part placements based on footprint identifiers is fundamentally wrong: footprint orientation depends on the individual component type and not the footprint, so rotating per footprint may give you wrong results. Nevertheless, there seem to be semi-strong conventions on how different footprints are oriented on the reels. For example, all SOT footprints seem to be 180° rotated, and most *SO* footprints are 270° off. Adding these two a correction file is much less work than adding the correction fields for each individual component.

To ensure that the footprint based correction can be overridden, it is applied only if the correction field doesn't exist. Also, if the command-line argument isn't given, there is no difference to the original behavior. I find this approach preferable to the "baking" suggestion presented in the issue because baking would either overwrite the existing corrections or be a one-shot operation.

The correction file is formatted according to the following example:
```
"Footprint pattern","X correction","Y correction","Rotation"
"^ESP32-WROOM-32",0,-2.25,270
"^SOP-4_",0,0,0
"^SOIC-8-1EP_",0,0,0
```

Fixes #115.