### PR TITLE
Implement a multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,10 @@ RUN export DEBIAN_FRONTEND="noninteractive" && apt-get update && \
       libgraphicsmagick1-dev libmagickcore-dev openscad && \
       rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install Pcbdraw
-
 # hack: manually install Python dependencies to speed up the build process
 # for repetitive builds
 
-RUN pip3 install numpy shapely click markdown2 pybars3 solidpython
+RUN pip3 install Pcbdraw numpy shapely click markdown2 pybars3 solidpython
 
 # create a new stage for building and installing KiKit
 FROM base AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 AS base
 
 LABEL maintainer="Jan \"yaqwsx\" Mrázek" \
       description="Container for running KiKit applications"
@@ -9,8 +9,31 @@ RUN export DEBIAN_FRONTEND="noninteractive" && apt-get update && \
     apt-get install -y --no-install-recommends \
       kicad kicad-libraries zip inkscape make git libmagickwand-dev \
       python3 python3-pip python3-wheel python3-setuptools inkscape \
-      libgraphicsmagick1-dev libmagickcore-dev openscad
+      libgraphicsmagick1-dev libmagickcore-dev openscad && \
+      rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install Pcbdraw KiKit
+RUN pip3 install Pcbdraw
+
+# hack: manually install Python dependencies to speed up the build process
+# for repetitive builds
+
+RUN pip3 install numpy shapely click markdown2 pybars3 solidpython
+
+# create a new stage for building and installing KiKit
+FROM base AS build
+
+COPY . /src/kikit
+WORKDIR /src/kikit
+RUN python3 setup.py install
+
+# the final stage only takes the installed packages from dist-packages 
+# and ignores the src directories
+FROM base
+COPY --from=build \
+    /usr/local/lib/python3.8/dist-packages \
+    /usr/local/lib/python3.8/dist-packages
+COPY --from=build \
+    /usr/local/bin \
+    /usr/local/bin
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,14 @@ RUN export DEBIAN_FRONTEND="noninteractive" && apt-get update && \
 # hack: manually install Python dependencies to speed up the build process
 # for repetitive builds
 
-RUN pip3 install Pcbdraw numpy shapely click markdown2 pybars3 solidpython
+RUN pip3 install \
+    "Pcbdraw ~= 0.6" \
+    "numpy ~= 1.20" \
+    "shapely ~= 1.7" \
+    "click ~= 7.1" \
+    "markdown2 ~= 2.4" \
+    "pybars3 ~= 0.9" \
+    "solidpython ~= 1.1"
 
 # create a new stage for building and installing KiKit
 FROM base AS build


### PR DESCRIPTION
I'm developing on a Mac, so I have to use Docker to run KiKit. The original Dockerfile installed kikit from PyPi; this PR modifies the approach so that the Docker image is built using the local filesystem version. To speed up the build process and to optimize the image size, I changed the Dockerfile into a multi-stage one, ditching the intermediate build directories.

As a hack, the Python install dependencies are now installed when building the base image. While this creates a bit of repetition and some maintenance burden, it also creates blindingly fast development cycles; it only takes 1.6s to build a new KiKit image version after source file changes.

I've also added the apt optimization proposed in PR #106.