### PR TITLE
Check AuxOrigin option for drill generation

### DIFF
--- a/kikit/export.py
+++ b/kikit/export.py
@@ -125,7 +125,11 @@ def gerberImpl(boardfile, outputdir, plot_plan=fullGerberPlotPlan, drilling=True
 
         mirror = False
         minimalHeader = settings["MinimalHeader"]
-        offset = board.GetDesignSettings().m_AuxOrigin
+        if settings["UseAuxOrigin"]:
+            offset = board.GetDesignSettings().m_AuxOrigin
+        else:
+            offset = wxPoint(0,0)
+
         # False to generate 2 separate drill files (one for plated holes, one for non plated holes)
         # True to generate only one drill file
         mergeNPTH = settings["MergeNPTH"]


### PR DESCRIPTION
This is a simple patch for #168. 

This change makes sure that both Gerber generation and Drill generation make use of the same origin.