### PR TITLE
Rotate footprint text correctly when rotating PCB when "keep upright" is set

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -504,6 +504,15 @@ class Panel:
         edges = []
         annotations = []
         for footprint in footprints:
+            # We want to rotate text within footprints by the requested amount,
+            # even if that text has "keep upright" attribute set. For that,
+            # the attribute must be first removed without changing the
+            # orientation of the text.
+            for item in (*footprint.GraphicalItems(), footprint.Value(), footprint.Reference()):
+                if isinstance(item, pcbnew.TEXTE_MODULE) and item.IsKeepUpright():
+                    actualOrientation = item.GetDrawRotation()
+                    item.SetKeepUpright(False)
+                    item.SetTextAngle(actualOrientation - footprint.GetOrientation())
             footprint.Rotate(originPoint, rotationAngle)
             footprint.Move(translation)
             edges += removeCutsFromFootprint(footprint)


### PR DESCRIPTION
This PR implements my proposal that was described in #177 some time ago... ("some time" turned out to be two months, yikes! Didn't have time to focus on this before).

Basically, the idea is that we remove "keep upright" attribute on all footprint text elements when adding a PCB to the panel. Those text elements include component reference, value, and all the strings that may be added manually via footprint editor - such as silkscreen text, copper text, etc. When removing the attribute, text usually changes its orientation, so we need to re-orient it to look exactly like it was before the attribute was removed. So, in the beginning we obtain the actual angle with which text is drawn on the PCB via `TEXTE_MODULE.GetDrawRotation()`, make it footprint-relative by subtracting `footprint.GetOrientation()`, remove "keep upright" attribute, and use precomputed angle as a new orientation for the text.

I've made a few manual tests to check if it works as expected. See files in the archive:
[test.zip](https://github.com/yaqwsx/KiKit/files/6840537/test.zip)
1. pcb_orient.kicad_pcb - the PCB that has been panelized
2. before.kicad_pcb - panel without changes from this PR
3. after.kicad_pcb - panel with changes from this PR
All the changes have been tested on KiCad 5.1.9. I expect it to work with all other KiCad 5 versions as well. 

Please let me know if you have any automated tests that I should take care of.