### PR TITLE
Dockerfile M1 Mac arm64

### DIFF
--- a/DockerfileM1Mac
+++ b/DockerfileM1Mac
@@ -5,7 +5,9 @@ LABEL maintainer="Jan \"yaqwsx\" Mrázek" \
 
 ENV DISPLAY=unix:0.0
 
-RUN  apt-get -qq update && apt-get -qq install -y software-properties-common gcc-aarch64-linux-gnu
+RUN apt-get update && \
+    apt-get install -y software-properties-common gcc-aarch64-linux-gnu && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN add-apt-repository --yes ppa:kicad/kicad-6.0-releases
 
@@ -20,8 +22,8 @@ RUN export DEBIAN_FRONTEND="noninteractive" && apt-get -qq update && \
 # for repetitive builds
 
 RUN pip3 install \
-    "Pcbdraw ~= 0.6" \
-    "numpy ~= 1.20" \
+    "Pcbdraw ~= 0.9" \
+    "numpy ~= 1.21.5" \
     "shapely ~= 1.7" \
     "click ~= 7.1" \
     "markdown2 ~= 2.4" \

--- a/DockerfileM1Mac
+++ b/DockerfileM1Mac
@@ -1,0 +1,48 @@
+FROM arm64v8/ubuntu:20.04 AS base
+
+LABEL maintainer="Jan \"yaqwsx\" Mrázek" \
+      description="Container for running KiKit applications"
+
+ENV DISPLAY=unix:0.0
+
+RUN  apt-get -qq update && apt-get -qq install -y software-properties-common gcc-aarch64-linux-gnu
+
+RUN add-apt-repository --yes ppa:kicad/kicad-6.0-releases
+
+RUN export DEBIAN_FRONTEND="noninteractive" && apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends \
+      kicad kicad-libraries zip inkscape make git libmagickwand-dev \
+      python3 python3-dev python3-pip python3-wheel python3-setuptools inkscape \
+      libgraphicsmagick1-dev libmagickcore-dev openscad && \
+      rm -rf /var/lib/apt/lists/*
+
+# hack: manually install Python dependencies to speed up the build process
+# for repetitive builds
+
+RUN pip3 install \
+    "Pcbdraw ~= 0.6" \
+    "numpy ~= 1.20" \
+    "shapely ~= 1.7" \
+    "click ~= 7.1" \
+    "markdown2 ~= 2.4" \
+    "pybars3 ~= 0.9" \
+    "solidpython ~= 1.1"
+
+# create a new stage for building and installing KiKit
+FROM base AS build
+
+COPY . /src/kikit
+WORKDIR /src/kikit
+RUN python3 setup.py install
+
+# the final stage only takes the installed packages from dist-packages
+# and ignores the src directories
+FROM base
+COPY --from=build \
+    /usr/local/lib/python3.8/dist-packages \
+    /usr/local/lib/python3.8/dist-packages
+COPY --from=build \
+    /usr/local/bin \
+    /usr/local/bin
+
+CMD ["bash"]


### PR DESCRIPTION
Adding a Docker file for M1 Macs, it differs from the main Dockerfile in:

- Changes the FROM tag to an arm64 ubuntu image. 
   `FROM arm64v8/ubuntu:20.04 AS base`

- Installs some extra packages not present in the arm64 base image 
   `RUN  apt-get -qq update && apt-get -qq install -y software-properties-common gcc-aarch64-linux-gnu`

- Installs **python3-dev**, needed to compile some packages that do not include arm64 wheels.
   ```
    RUN export DEBIAN_FRONTEND="noninteractive" && apt-get -qq update && \
    apt-get -qq install -y --no-install-recommends \
    kicad kicad-libraries zip inkscape make git libmagickwand-dev \
    python3 python3-dev python3-pip python3-wheel python3-setuptools inkscape \
    libgraphicsmagick1-dev libmagickcore-dev openscad && \
    rm -rf /var/lib/apt/lists/*
```