### PR TITLE
Fix unclosable dialog

### DIFF
--- a/pcm/kikit/plugins/__init__.py
+++ b/pcm/kikit/plugins/__init__.py
@@ -35,7 +35,7 @@ class MissingKiKitDialog(wx.Dialog):
         if self.IsModal():
             self.EndModal(0)
         else:
-            self.Close(true)
+            self.Close(True)
 
 
 try:


### PR DESCRIPTION
Trivial typo fix that was preventing the "No KiKit backend found!" from being dismissed with the OK button.