### PR TITLE
Make copperFillNonBoardAreas multilayer, fix missing tolerance in makeGrid, improve docs

### DIFF
--- a/doc/panelization.md
+++ b/doc/panelization.md
@@ -386,7 +386,10 @@ locateBoard(inputFilename, expandDist=None)
 ```
 Given a board filename, find its source area and optionally expand it by the given distance.
 
+Parameters:
+
 inputFilename - the path to the board file
+
 expandDist - the distance by which to expand the board outline in each direction to ensure elements that are outside the board are included
 
 #### `makeFrame`
@@ -398,9 +401,13 @@ boards substrates and the frame. Return a tuple of vertical and
 horizontal cuts.
 
 Parameters:
+
 width - width of substrate around board outlines
+
 slotwidth - width of milled-out perimeter around board outline
+
 hspace - horizontal space between board outline and substrate
+
 vspace - vertical space between board outline and substrate
 
 #### `makeFrameCutsH`
@@ -429,27 +436,39 @@ placementClass. The nets and references are renamed according to the
 patterns.
 
 Parameters:
+
 boardfile - the path to the filename of the board to be added
+
 sourceArea - the region within the file specified to be selected (see also tolerance, below)
     set to None to automatically calculate the board area from the board file with the given tolerance
+
 rows - the number of boards to place in the vertical direction
+
 cols - the number of boards to place in the horizontal direction
+
 destination - the center coordinates of the first board in the grid (for example, wxPointMM(100,50))
+
 verSpace - the vertical spacing (distance, not pitch) between boards
+
 horSpace - the horizontal spacing (distance, not pitch) between boards
+
 rotation - the rotation angle to be applied to the source board before placing it
+
 placementClass - the placement rules for boards. The builtin classes are:
     BasicGridPosition - places each board in its original orientation
     OddEvenColumnPosition - every second column has the boards rotated by 180 degrees
     OddEvenRowPosition - every second row has the boards rotated by 180 degrees
     OddEvenRowsColumnsPosition - every second row and column has the boards rotated by 180 degrees
+
 netRenamePattern - the pattern according to which the net names are transformed
     The default pattern is "Board_{n}-{orig}" which gives each board its own instance of its nets, 
     i.e. GND becomes Board_0-GND for the first board , and Board_1-GND for the second board etc
+
 refRenamePattern - the pattern according to which the reference designators are transformed
     The default pattern is "Board_{n}-{orig}" which gives each board its own instance of its reference designators,
     so R1 becomes Board_0-R1 for the first board, Board_1-R1 for the recond board etc. To keep references the
     same as in the original, set this to "{orig}"
+
 tolerance - if no sourceArea is specified, the distance by which the selection 
     area for the board should extend outside the board edge.
     If you have any objects that are on or outside the board edge, make sure this is big enough to include them.
@@ -492,9 +511,13 @@ Build a full frame with board perimeter milled out.
 Add your boards to the panel first using appendBoard or makeGrid.
 
 Parameters:
+
 width - width of substrate around board outlines
+
 slotwidth - width of milled-out perimeter around board outline
+
 hspace - horizontal space between board outline and substrate
+
 vspace - vertical space between board outline and substrate
 
 #### `makeVCuts`

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -882,27 +882,39 @@ class Panel:
         patterns.
 
         Parameters:
+        
         boardfile - the path to the filename of the board to be added
+        
         sourceArea - the region within the file specified to be selected (see also tolerance, below)
             set to None to automatically calculate the board area from the board file with the given tolerance
+        
         rows - the number of boards to place in the vertical direction
+        
         cols - the number of boards to place in the horizontal direction
+        
         destination - the center coordinates of the first board in the grid (for example, wxPointMM(100,50))
+        
         verSpace - the vertical spacing (distance, not pitch) between boards
+        
         horSpace - the horizontal spacing (distance, not pitch) between boards
+        
         rotation - the rotation angle to be applied to the source board before placing it
+        
         placementClass - the placement rules for boards. The builtin classes are:
             BasicGridPosition - places each board in its original orientation
             OddEvenColumnPosition - every second column has the boards rotated by 180 degrees
             OddEvenRowPosition - every second row has the boards rotated by 180 degrees
             OddEvenRowsColumnsPosition - every second row and column has the boards rotated by 180 degrees
+        
         netRenamePattern - the pattern according to which the net names are transformed
             The default pattern is "Board_{n}-{orig}" which gives each board its own instance of its nets, 
             i.e. GND becomes Board_0-GND for the first board , and Board_1-GND for the second board etc
+        
         refRenamePattern - the pattern according to which the reference designators are transformed
             The default pattern is "Board_{n}-{orig}" which gives each board its own instance of its reference designators,
             so R1 becomes Board_0-R1 for the first board, Board_1-R1 for the recond board etc. To keep references the
             same as in the original, set this to "{orig}"
+        
         tolerance - if no sourceArea is specified, the distance by which the selection 
             area for the board should extend outside the board edge.
             If you have any objects that are on or outside the board edge, make sure this is big enough to include them.
@@ -927,9 +939,13 @@ class Panel:
         horizontal cuts.
         
         Parameters:
+        
         width - width of substrate around board outlines
+        
         slotwidth - width of milled-out perimeter around board outline
+        
         hspace - horizontal space between board outline and substrate
+        
         vspace - vertical space between board outline and substrate
         
         """
@@ -953,10 +969,15 @@ class Panel:
         Add your boards to the panel first using appendBoard or makeGrid.
         
         Parameters:
+        
         width - width of substrate around board outlines
+        
         slotwidth - width of milled-out perimeter around board outline
+        
         hspace - horizontal space between board outline and substrate
+        
         vspace - vertical space between board outline and substrate
+        
         """
         self.makeFrame(width, hspace, vspace)
         boardSlot = GeometryCollection()
@@ -1339,7 +1360,10 @@ class Panel:
         """
         Given a board filename, find its source area and optionally expand it by the given distance.
         
+        Parameters:
+        
         inputFilename - the path to the board file
+        
         expandDist - the distance by which to expand the board outline in each direction to ensure elements that are outside the board are included
         """
         inputBoard = pcbnew.LoadBoard(inputFilename)


### PR DESCRIPTION
- Adds support for inner layers to copperFillNonBoardAreas (API compatible, optional parameter)
- cFNBA now takes a list of layer IDs, with F_Cu and B_Cu by default
- locateBoard helper function added, with tolerance support
- makeGrid now has an extra, optional (for API compatibility) tolerance parameter
- mG tolerance parameter is used if sourceArea is None
- makeGrid, makeFrame, and makeTightFrame have their parameters documented in detail