### PR TITLE
Fix rotation for checkerboard pattern

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -71,7 +71,7 @@ class OddEvenRowsColumnsPosition(BasicGridPosition):
     Rotate boards by 180 for every row and column
     """
     def rotation(self, i, j):
-        if (i * j) % 2 == 0:
+        if (i % 2) == (j % 2):
             return 0
         return 1800
 


### PR DESCRIPTION
Previous implementation doesn't work as intended, because when one of the inputs is zero, zero is always returned, as zero multiplied by any number is zero, which is even. So in the first row and column, all boards have zero degrees rotation, instead of the alternating pattern we want.