### PR TITLE
 Use -O options with curl to download linked file

### DIFF
--- a/doc/macosInstallation.md
+++ b/doc/macosInstallation.md
@@ -30,7 +30,7 @@ here](../scripts/installMacOS.bash). You can download and run it. Open a
 terminal and enter:
 
 ```.bash
-$ curl https://raw.githubusercontent.com/yaqwsx/KiKit/master/scripts/installMacOS.bash
+$ curl -O https://raw.githubusercontent.com/yaqwsx/KiKit/master/scripts/installMacOS.bash
 $ sudo bash installMacOS.bash
 ```
 


### PR DESCRIPTION
curl needs the -O option on macOs to download the file rather than pass it to stdout.