### PR TITLE
remove copper from mouse bites

### DIFF
--- a/kikit/resources/kikit.pretty/NPTH.kicad_mod
+++ b/kikit/resources/kikit.pretty/NPTH.kicad_mod
@@ -5,5 +5,5 @@
   (fp_text value NPTH (at 0 -0.5) (layer F.Fab) hide
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (pad "" np_thru_hole circle (at 0 0) (size 1 1) (drill 1) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at 0 0) (size 1 1) (drill 1) (layers *.Mask))
 )


### PR DESCRIPTION
kikit mouse bites use the non-plated through hole footprint
NPTH.kicad_mod .
this footprint has copper pad on the copper layer.
since there are as large as the drill size, they will be removed
during fabrication only if the alignment is perfect.
but these copper pads can also cause DRC errors, since copper is
too close to the edge.
removing the copper pad from the mouse bites solves these two
issues.