### PR TITLE
add refill post option

### DIFF
--- a/doc/panelizeCli.md
+++ b/doc/panelizeCli.md
@@ -552,5 +552,7 @@ Finishing touches to the panel.
 - `origin` - specify if the auxilary origin an grid origin should be placed. Can
   be one of `tl`, `tr`, `bl`, `br` (corners), `mt`, `mb`, `ml`, `mr` (middle of
   sides), `c` (center). Empty string does not changes the origin.
-
+- `refill` - Refill all zones, including the panelized board copper planes. This
+  ensures the clearances around inserted objects, such as mouse bites, are
+  applied.
 

--- a/kikit/panelize_ui.py
+++ b/kikit/panelize_ui.py
@@ -283,7 +283,7 @@ def doPanelization(input, output, preset, plugins=[]):
 
     ki.buildDebugAnnotation(preset["debug"], panel)
 
-    panel.save(reconstructArcs=preset["post"]["reconstructarcs"])
+    panel.save(reconstructArcs=preset["post"]["reconstructarcs"], refillAllZones=preset["post"]["refill"])
 
 
 @click.command()

--- a/kikit/panelize_ui_sections.py
+++ b/kikit/panelize_ui_sections.py
@@ -594,7 +594,10 @@ POST_SECTION = {
     "origin": SChoice(
         ANCHORS + [""],
         always(),
-        "Place auxiliary origin")
+        "Place auxiliary origin"),
+    "refill": SBool(
+        always(),
+        "Refill all zones")
 }
 
 def ppPost(section):

--- a/kikit/resources/panelizePresets/default.json
+++ b/kikit/resources/panelizePresets/default.json
@@ -114,7 +114,8 @@
         "millradius": "0mm",
         "script": "",
         "scriptarg": "",
-        "origin": "tl"
+        "origin": "tl",
+        "refill": false
     },
     "page": {
         "type": "inherit",


### PR DESCRIPTION
the added configuration->post->refill option allows to refill all
zones, including the copper planes from the panelized board.
this ensures clearances around the mouse bites are applied.
this option is disabled by default, so to not alter the original
design.