### PR TITLE
Update export.py to support 6.99

### DIFF
--- a/kikit/export.py
+++ b/kikit/export.py
@@ -85,7 +85,10 @@ def gerberImpl(boardfile, outputdir, plot_plan=fullGerberPlotPlan, drilling=True
     popt.SetIncludeGerberNetlistInfo(True)
     popt.SetCreateGerberJobFile(True)
     popt.SetUseGerberProtelExtensions(settings["UseGerberProtelExtensions"])
-    popt.SetExcludeEdgeLayer(settings["ExcludeEdgeLayer"])
+    try: # kicad < 6.99
+        popt.SetExcludeEdgeLayer(settings["ExcludeEdgeLayer"])
+    except AttributeError:
+        pass
     popt.SetScale(1)
     popt.SetUseAuxOrigin(settings["UseAuxOrigin"])
     popt.SetUseGerberX2format(False)
@@ -139,7 +142,9 @@ def gerberImpl(boardfile, outputdir, plot_plan=fullGerberPlotPlan, drilling=True
         if settings["UseAuxOrigin"]:
             offset = board.GetDesignSettings().GetAuxOrigin()
         else:
-            offset = wxPoint(0,0)
+            # wxPoint in < 6.99, VECTOR2I in >=6.99 
+            OffsetType = type(board.GetDesignSettings().GetAuxOrigin())
+            offset = OffsetType(0,0)
 
         # False to generate 2 separate drill files (one for plated holes, one for non plated holes)
         # True to generate only one drill file
@@ -170,7 +175,10 @@ def pasteDxfExport(board, plotDir):
     popt.SetAutoScale(False)
     popt.SetScale(1)
     popt.SetMirror(False)
-    popt.SetExcludeEdgeLayer(True)
+    try: # kicad < 6.99
+        popt.SetExcludeEdgeLayer(True)  
+    except AttributeError:             
+        pass
     popt.SetScale(1)
     popt.SetDXFPlotUnits(DXF_UNITS_MILLIMETERS)
     popt.SetDXFPlotPolygonMode(False)


### PR DESCRIPTION
These changes fix the workflow for fabrication output generation in 6.99.


**Version**

`
Application: KiCad
Version: (6.99.0-2103-gdc6c27b686), release build
Platform: macOS Version 12.4 (Build 21F79), 64 bit, Little endian, wxMac
`


**Test Case**

`
kikit fab jlcpcb --no-drc ./Untitled.kicad_pcb ./out
`


**Issue 1**

SetExcludeEdgeLayer is not available in 6.99.

`
  File "/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/kikit/export.py", line 88, in gerberImpl
    popt.SetExcludeEdgeLayer(settings["ExcludeEdgeLayer"])
AttributeError: 'PCB_PLOT_PARAMS' object has no attribute 'SetExcludeEdgeLayer'
`

Fix is to apply an exception escape hatch as seen in https://github.com/AislerHQ/PushForKiCad/issues/14#issuecomment-1122398242


**Issue 2**

The type of the aOffset parameter for EXCELLON_WRITER_SetOptions has changed.

`
/site-packages/pcbnew.py", line 8005, in SetOptions
    return _pcbnew.EXCELLON_WRITER_SetOptions(self, aMirror, aMinimalHeader, aOffset, aMerge_PTH_NPTH)
TypeError: in method 'EXCELLON_WRITER_SetOptions', argument 4 of type 'VECTOR2I const &'
`

Instead of hardcoding the type, use the type returned by `board.GetDesignSettings().GetAuxOrigin()`
