### PR TITLE
MacOS install script fix

### DIFF
--- a/scripts/installMacOS.bash
+++ b/scripts/installMacOS.bash
@@ -22,7 +22,7 @@ codesign -fs "kikit" "$KICAD_PYTHON/Resources/Python.app"
 codesign -fs "kikit" "/Applications/KiCad/KiCad.app"
 codesign -fs "kikit" "/Applications/KiCad/KiCad.app/Contents/Applications/pcbnew.app"
 
-cat << EOF | > /usr/local/bin/kikit
+cat << EOF  > /usr/local/bin/kikit
 #!/bin/bash
 $KICAD_PYTHON/bin/python3 -m kikit.ui "\$@"
 EOF


### PR DESCRIPTION
fixed pipe problem so MacOS install works now per issue 363
I have verified this works but still requires sudo permission, I was not able to make it work without.

 https://github.com/yaqwsx/KiKit/issues/363