### PR TITLE
Fix typo referring to wrong method in error message.

### DIFF
--- a/kikit/plugin.py
+++ b/kikit/plugin.py
@@ -192,7 +192,7 @@ class CutsPlugin:
         """
         Render any other type of cuts (frame, backbone, etc.)
         """
-        raise NotImplementedError("Cuts plugin has to provide renderTabCuts")
+        raise NotImplementedError("Cuts plugin has to provide renderOtherCuts")
 
 
 class ToolingPlugin:


### PR DESCRIPTION
There is a problem with the NotImplementedError in the plugins file. Says renderTabCuts inside the renderOtherCuts function. I was testing the renderTabCuts and had misspelled the renderOtherCuts and I kept banging my head into the wrong function.