### PR TITLE
Enable the creation of deep copies of BaseValue objects

### DIFF
--- a/kikit/units.py
+++ b/kikit/units.py
@@ -1,6 +1,7 @@
 import re
 import math
 from pcbnewTransition import pcbnew
+from copy import deepcopy
 
 class UnitError(RuntimeError):
     pass
@@ -22,6 +23,16 @@ class BaseValue(int):
     """
     Value in base units that remembers its original string representation.
     """
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        value = self
+        strRepr = self.str
+        result = cls.__new__(cls, value, strRepr)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            setattr(result, k, deepcopy(v, memo))
+        return result
+
     def __new__(cls, value, strRepr):
         x = super().__new__(cls, value)
         x.str = strRepr

--- a/test/units/test_units.py
+++ b/test/units/test_units.py
@@ -1,6 +1,7 @@
 import pytest
 from pcbnewTransition.pcbnew import FromMM, FromMils
 from kikit.units import readLength, readAngle, UnitError
+from copy import deepcopy
 
 def test_readLength():
     assert readLength("4.24mm") == FromMM(4.24)
@@ -13,3 +14,9 @@ def test_readLength():
     assert readLength("1mil") == FromMils(1)
     assert readLength("1inch") == FromMils(1000)
 
+
+def test_baseValue_deepcopy():
+    a = readLength("1.23mm")
+    b = deepcopy(a)
+
+    assert a.__dict__ == b.__dict__


### PR DESCRIPTION
Imports deepcopy from copy and adds the `__deepcopy__()` special method to `BaseValue`.

Refs #444 