### PR TITLE
Replace EDA_RECT with BOX2I for KiCAD 6.99

### DIFF
--- a/kikit/common.py
+++ b/kikit/common.py
@@ -4,7 +4,11 @@ from kikit.defs import Layer
 from kikit.typing import Box
 from pcbnewTransition import pcbnew, isV6
 from kikit.intervals import Interval, AxialLine
-from pcbnew import wxPoint, wxRect, EDA_RECT
+from pcbnew import wxPoint, wxRect
+try:
+    from pcbnew import EDA_RECT
+except ImportError:
+    from pcbnew import BOX2I as EDA_RECT
 import os
 from itertools import product, chain, islice
 import numpy as np


### PR DESCRIPTION
`EDA_RECT` was removed about 2 months ago [RIP EDA_RECT commit @ KiCAD GitLab](https://gitlab.com/kicad/code/kicad/-/commit/9188838e5016d1ebbd54b5eed4d8f1446420d23a). 

This results in an import error with the latest nightly build:

```
from pcbnew import wxPoint, wxRect, EDA_RECT
ImportError: cannot import name 'EDA_RECT' from 'pcbnew' (C:\Program Files\KiCad\6.99\bin\Lib\site-packages\pcbnew.py)
```

To keep compatibility we try to import `EDA_RECT` and if that fails we import `BOX2I` as `EDA_RECT`.