### PR TITLE
fix order of components in pos file by Designator

### DIFF
--- a/kikit/fab/common.py
+++ b/kikit/fab/common.py
@@ -204,10 +204,18 @@ def collectPosData(board, correctionFields, posFilter=lambda x : True,
              footprintOrientation(footprint, getCompensation(footprint))) for footprint in footprints]
 
 def posDataToFile(posData, filename):
+    def getComponentOrd(s):
+        val = 0
+        for i in re.search(r'^[^\d]+(?=\d)', s).group():
+                val += ord(i)
+        return val
+    def getComponentNum(s):
+        return int(re.search(r'\d+', s).group())
     with open(filename, "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(["Designator", "Mid X", "Mid Y", "Layer", "Rotation"])
-        for line in sorted(posData, key=lambda x: x[0]):
+        posData.sort(key=lambda x: getComponentNum(x[0]))
+        for line in sorted(posData, key=lambda x: getComponentOrd(x[0])):
             line = list(line)
             for i in [1, 2, 4]:
                 line[i] = f"{line[i]:.2f}" # Most Fab houses expect only 2 decimal digits

--- a/kikit/fab/pcbway.py
+++ b/kikit/fab/pcbway.py
@@ -87,12 +87,6 @@ def collectBom(components, manufacturerFields, partNumberFields,
         bom[cType] = bom.get(cType, []) + [reference]
     return bom
 
-def natural_sort(l):
-    #https://stackoverflow.com/questions/4836710/is-there-a-built-in-function-for-string-natural-sort
-    convert = lambda text: int(text) if text.isdigit() else text.lower()
-    alphanum_key = lambda key: [ convert(c) for c in re.split('([0-9]+)', key) ]
-    return sorted(l, key = alphanum_key)
-
 def bomToCsv(bomData, filename, nBoards, types):
     with open(filename, "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
@@ -105,9 +99,11 @@ def bomToCsv(bomData, filename, nBoards, types):
         for cType, references in bomData.items():
             tmp[references[0]] = (references, cType)
 
-        for i in natural_sort(tmp):
+        sorter = NaturalSorter(selector=lambda x: x)
+
+        for i in sorter.sort(tmp):
             references, cType = tmp[i]
-            references = natural_sort(references)
+            references = sorter.sort(references)
             description, footprint, manufacturer, partNumber, notes, solderType = cType
             if solderType is None:
                 solderType = types[references[0]]


### PR DESCRIPTION
Previously the generated .pos file was ordered like this:

C1,C10,C11,C2,C3...

now the order is:

C1,C2,C3...,C10...

I used two sorts so I hope performance won't be an issue.