### PR TITLE
Fix: B_Cu was missing in the list of all Cu layers

### DIFF
--- a/kikit/defs.py
+++ b/kikit/defs.py
@@ -56,7 +56,7 @@ class Layer(IntEnum):
 
     @staticmethod
     def allCu():
-        return list(range(Layer.F_Cu, Layer.B_Cu))
+        return list(range(Layer.F_Cu, Layer.B_Cu + 1))
 
 class STROKE_T(IntEnum):
     S_SEGMENT = 0


### PR DESCRIPTION
The last item returned by range(start, stop) does _not_ include the stop item itself. Hence, B_Cu was missing from the list of copper layers.