### PR TITLE
Apply V-cut Cu keepout zones to all Cu layers

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -1668,7 +1668,7 @@ class Panel:
 
     def addKeepout(self, area, noTracks=True, noVias=True, noCopper=True):
         """
-        Add a keepout area from top and bottom layers. Area is a shapely
+        Add a keepout area to all copper layers. Area is a shapely
         polygon. Return the keepout area.
         """
         zone = polygonToZone(area, self.board)
@@ -1677,10 +1677,7 @@ class Panel:
         zone.SetDoNotAllowVias(noVias)
         zone.SetDoNotAllowCopperPour(noCopper)
 
-        zone.SetLayer(Layer.F_Cu)
-        layerSet = zone.GetLayerSet()
-        layerSet.AddLayer(Layer.B_Cu)
-        zone.SetLayerSet(layerSet)
+        zone.SetLayerSet(pcbnew.LSET.AllCuMask())
 
         self.board.Add(zone)
         return zone


### PR DESCRIPTION
To avoid copper chip formation and to ease board separation, it is important to keep copper out of V-cut areas. This does not only apply to the outer copper layers (as implemented before), but to all copper layers within the PCB layer stack.