### PR TITLE
 variables in nametemplate

### DIFF
--- a/doc/fabrication.md
+++ b/doc/fabrication.md
@@ -22,7 +22,8 @@ All commands also support the following options:
 - `--nametemplate <str>`:  If you want to name your files differently, specify
   this option. This option takes a string that should contain `{}`. This string
   will be replaced by `gerber`, `pos` or `bom` in the out file names. The
-  extension is appended automatically.
+  extension is appended automaticall. [Variables in text](panelizeCli.md#available-variables-in-text)
+  are also supported eg: `{boardTitle}_rev{boardRevision}_{date}_{}`.
 
 Each of the fab command also take additional, manufacturer specific, options.
 See documentation for the individual manufacturer below:

--- a/doc/panelizeCli.md
+++ b/doc/panelizeCli.md
@@ -481,6 +481,8 @@ option from `postprocess`.
 
 - `date` - formats current date as `<year>-<month>-<day>`
 - `time24` - formats current time in 24-hour format
+- `year`, `month`, `day`, `hour`, `minute`, `second` - individual variables 
+  for any date format 
 - `boardTitle` - the title from the source board
 - `boardDate` - the date from the source board
 - `boardRevision` - the revision from the source board

--- a/kikit/fab/common.py
+++ b/kikit/fab/common.py
@@ -9,6 +9,7 @@ from kikit.defs import MODULE_ATTR_T
 from kikit.drc_ui import ReportLevel
 from kikit import drc
 from kikit import eeschema, eeschema_v6
+from kikit.text import kikitTextVars
 import sys
 
 if isV6() or isV7():
@@ -221,3 +222,11 @@ def ensureValidSch(filename):
 def ensureValidBoard(filename):
     if not isValidBoardPath(filename):
         raise RuntimeError(f"The path {filename} is not a valid KiCAD PCB file")
+
+def expandNameTemplate(template: str, filetype: str, board: pcbnew.BOARD) -> str:
+
+    textVars = kikitTextVars(board)
+    try:
+        return template.format(filetype, **textVars)
+    except KeyError as e:
+        raise RuntimeError(f"Unknown variable {e} in --nametemplate: {template}")

--- a/kikit/fab/jlcpcb.py
+++ b/kikit/fab/jlcpcb.py
@@ -71,7 +71,8 @@ def exportJlcpcb(board, outputdir, assembly, schematic, ignore, field,
     gerberdir = os.path.join(outputdir, "gerber")
     shutil.rmtree(gerberdir, ignore_errors=True)
     gerberImpl(board, gerberdir)
-    archiveName = nametemplate.format("gerbers")
+
+    archiveName = expandNameTemplate(nametemplate, "gerbers", loadedBoard)
     shutil.make_archive(os.path.join(outputdir, archiveName), "zip", outputdir, "gerber")
 
     if not assembly:
@@ -103,5 +104,5 @@ def exportJlcpcb(board, outputdir, assembly, schematic, ignore, field,
     if missingFields and missingerror:
         sys.exit("There are components with missing ordercode, aborting")
 
-    posDataToFile(posData, os.path.join(outputdir, nametemplate.format("pos") + ".csv"))
-    bomToCsv(bom, os.path.join(outputdir, nametemplate.format("bom") + ".csv"))
+    posDataToFile(posData, os.path.join(outputdir, expandNameTemplate(nametemplate, "pos", loadedBoard) + ".csv"))
+    bomToCsv(bom, os.path.join(outputdir, expandNameTemplate(nametemplate, "bom", loadedBoard) + ".csv"))

--- a/kikit/fab/oshpark.py
+++ b/kikit/fab/oshpark.py
@@ -3,7 +3,7 @@ import os
 import shutil
 from pathlib import Path
 from kikit.export import gerberImpl, exportSettingsOSHPark, fullGerberPlotPlan
-from kikit.fab.common import ensurePassingDrc
+from kikit.fab.common import ensurePassingDrc, expandNameTemplate
 
 plotPlanNoVCuts = [(name, id, comment) for name, id, comment in fullGerberPlotPlan if name != "CmtUser"]
 
@@ -20,5 +20,6 @@ def exportOSHPark(board, outputdir, nametemplate, drc):
     gerberdir = os.path.join(outputdir, "gerber")
     shutil.rmtree(gerberdir, ignore_errors=True)
     gerberImpl(board, gerberdir, plot_plan=plotPlanNoVCuts, settings=exportSettingsOSHPark)
-    archiveName = nametemplate.format("gerbers")
+
+    archiveName = expandNameTemplate(nametemplate, "gerbers", loadedBoard)
     shutil.make_archive(os.path.join(outputdir, archiveName), "zip", outputdir, "gerber")

--- a/kikit/fab/pcbway.py
+++ b/kikit/fab/pcbway.py
@@ -137,7 +137,8 @@ def exportPcbway(board, outputdir, assembly, schematic, ignore,
     gerberdir = os.path.join(outputdir, "gerber")
     shutil.rmtree(gerberdir, ignore_errors=True)
     gerberImpl(board, gerberdir, settings=exportSettingsPcbway)
-    archiveName = nametemplate.format("gerbers")
+
+    archiveName = expandNameTemplate(nametemplate, "gerbers", loadedBoard)
     shutil.make_archive(os.path.join(outputdir, archiveName), "zip", outputdir, "gerber")
 
     if not assembly:
@@ -172,6 +173,6 @@ def exportPcbway(board, outputdir, assembly, schematic, ignore,
         sys.exit("There are components with missing ordercode, aborting")
 
     posData = collectPosData(loadedBoard, correctionFields, bom=components, correctionFile=correctionpatterns)
-    posDataToFile(posData, os.path.join(outputdir, nametemplate.format("pos") + ".csv"))
+    posDataToFile(posData, os.path.join(outputdir, expandNameTemplate(nametemplate, "pos", loadedBoard) + ".csv"))
     types = collectSolderTypes(loadedBoard)
-    bomToCsv(bom, os.path.join(outputdir, nametemplate.format("bom") + ".csv"), nboards, types)
+    bomToCsv(bom, os.path.join(outputdir, expandNameTemplate(nametemplate, "bom", loadedBoard) + ".csv"), nboards, types)

--- a/kikit/text.py
+++ b/kikit/text.py
@@ -28,6 +28,12 @@ def kikitTextVars(board: pcbnew.BOARD, vars: Dict[str, str]={}) -> Dict[str, Any
     availableVars: Dict[str, Formatter] = {
         "date": Formatter(lambda: dt.datetime.today().strftime("%Y-%m-%d"), vars),
         "time24": Formatter(lambda: dt.datetime.today().strftime("%H:%M"), vars),
+        "year": Formatter(lambda: dt.datetime.today().strftime("%Y"), vars),
+        "month": Formatter(lambda: dt.datetime.today().strftime("%m"), vars),
+        "day": Formatter(lambda: dt.datetime.today().strftime("%d"), vars),
+        "hour": Formatter(lambda: dt.datetime.today().strftime("%H"), vars),
+        "minute": Formatter(lambda: dt.datetime.today().strftime("%M"), vars),
+        "second": Formatter(lambda: dt.datetime.today().strftime("%S"), vars),
         "boardTitle": Formatter(lambda: board.GetTitleBlock().GetTitle(), vars),
         "boardDate": Formatter(lambda: board.GetTitleBlock().GetDate(), vars),
         "boardRevision": Formatter(lambda: board.GetTitleBlock().GetRevision(), vars),


### PR DESCRIPTION
I like to include the name of the project and date in fabrication file names, while `kikit fab` support the --nametemplate argument, information already available in kicad need to be added manually.
All variables are already exposed for the [text section] (https://github.com/yaqwsx/KiKit/blob/master/doc/panelizeCli.md#available-variables-in-text) this PR extends the functionality to the --nametemplate argument for fabrication output file naming. It also adds a new variable `timestamp` which can be safely used a file name.
usage:
`kikit fab oshpark --no-drc kicad-project.kicad_pcb --nametemplate "{boardTitle}_rev{boardRevision}_{timestamp}_{}" output` 