### PR TITLE
Fix fallthrough of comma-separated fields for JLCPCB order code

### DIFF
--- a/kikit/fab/jlcpcb.py
+++ b/kikit/fab/jlcpcb.py
@@ -26,7 +26,7 @@ def collectBom(components, lscsFields, ignore):
         orderCode = None
         for fieldName in lscsFields:
             orderCode = getField(c, fieldName)
-            if orderCode is not None:
+            if orderCode is not None and orderCode.strip() != "":
                 break
         cType = (
             getField(c, "Value"),


### PR DESCRIPTION
Fixes #485