### PR TITLE
jlcpcb: include board name in gerbers.zip instead of just "gerbers.zip"

### DIFF
--- a/kikit/fab/jlcpcb.py
+++ b/kikit/fab/jlcpcb.py
@@ -72,7 +72,8 @@ def exportJlcpcb(board, outputdir, assembly, schematic, ignore, field,
     shutil.rmtree(gerberdir, ignore_errors=True)
     gerberImpl(board, gerberdir)
 
-    archiveName = expandNameTemplate(nametemplate, "gerbers", loadedBoard)
+    boardName = os.path.basename(board.replace(".kicad_pcb", ""))
+    archiveName = expandNameTemplate(nametemplate, boardName + "-gerbers", loadedBoard)
     shutil.make_archive(os.path.join(outputdir, archiveName), "zip", outputdir, "gerber")
 
     if not assembly:


### PR DESCRIPTION
Output of "fab jlcpcb" is named "gerbers.zip" which makes it somewhat difficult when uploading multiple boards to JLC cart.

This changes the default name (unless `--nametemplate` is specified) to `<board_name>-gerbers.zip`.