### PR TITLE
create /usr/local/bin if it doesn't exist

### DIFF
--- a/scripts/installMacOS.bash
+++ b/scripts/installMacOS.bash
@@ -22,6 +22,8 @@ codesign -fs "kikit" "$KICAD_PYTHON/Resources/Python.app"
 codesign -fs "kikit" "/Applications/KiCad/KiCad.app"
 codesign -fs "kikit" "/Applications/KiCad/KiCad.app/Contents/Applications/pcbnew.app"
 
+mkdir -p /usr/local/bin
+
 cat << EOF  > /usr/local/bin/kikit
 #!/bin/bash
 $KICAD_PYTHON/bin/python3 -m kikit.ui "\$@"


### PR DESCRIPTION
/usr/local starts out empty on recent versions of macOS