### PR TITLE
Reduce layerset of V-cut Cu clearance keepouts to used Cu layers

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -1779,7 +1779,7 @@ class Panel:
         zone.SetDoNotAllowVias(noVias)
         zone.SetDoNotAllowCopperPour(noCopper)
 
-        zone.SetLayerSet(pcbnew.LSET.AllCuMask())
+        zone.SetLayerSet(pcbnew.LSET.AllCuMask(self.copperLayerCount))
 
         self.board.Add(zone)
         return zone


### PR DESCRIPTION
Fixing my own code (#461).

If we use `AllCuMask()` without an argument, we get all 32 Cu layers in the layerset (literally `*.Cu` in the `.kicad_pcb` file), which causes the DRC to report items on inactive layers. To avoid this, we now use only the actual number of Cu layers used in the panel (resulting in a list of layers in the `.kicad_pcb` file).