### PR TITLE
Let the Mac installer detect the Python version

### DIFF
--- a/scripts/installMacOS.bash
+++ b/scripts/installMacOS.bash
@@ -6,21 +6,53 @@ if [ "$EUID" -ne 0 ]
   exit
 fi
 
-V=3.8
-KICAD_PYTHON="/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/$V"
+EDITABLE=0
+KICAD_PYTHON_BASE="/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions"
 CERTIFICATE="kikit"
+
+
+# Read command line options
+while getopts ":p:c:e" opt; do
+  case $opt in
+    p) 
+      KICAD_PYTHON_BASE="$OPTARG"
+    ;;
+    c) 
+      CERTIFICATE="$OPTARG"
+    ;;
+    e) 
+      EDITABLE=1
+    ;;
+    \?) 
+      echo "Invalid option -$OPTARG" >&2
+      exit 1
+    ;;
+  esac
+done
+
+# KiCad 7 has an updated Python version; get the Python version from the KiCad Application
+# directory.
+
+V=$(basename "$KICAD_PYTHON_BASE"/?.?)
+KICAD_PYTHON="$KICAD_PYTHON_BASE/$V"
+
 
 echo "Kicad Python dir: $KICAD_PYTHON" 1>&2
 echo "Python version: $V" 1>&2
-echo "Signinf certificate: $CERTIFICATE" 1>&2
+echo "Signing certificate: $CERTIFICATE" 1>&2
 
-echo "KiKit will be installed" 1>&2
-$KICAD_PYTHON/bin/python3 -m pip install kikit
+if [ $EDITABLE -eq 1 ]; then
+    echo "Installing editable version of kikit" 1>&2
+    $KICAD_PYTHON/bin/python3 -m pip install -e .
+else
+    echo "Installing kikit from PyPI" 1>&2
+    $KICAD_PYTHON/bin/python3 -m pip install kikit
+fi
 
-echo "KiCAD will be resigned" 1>&2
-codesign -fs "kikit" "$KICAD_PYTHON/Resources/Python.app"
-codesign -fs "kikit" "/Applications/KiCad/KiCad.app"
-codesign -fs "kikit" "/Applications/KiCad/KiCad.app/Contents/Applications/pcbnew.app"
+echo "KiCAD will be re-signed" 1>&2
+codesign -fs "$CERTIFICATE" "$KICAD_PYTHON/Resources/Python.app"
+codesign -fs "$CERTIFICATE" "/Applications/KiCad/KiCad.app"
+codesign -fs "$CERTIFICATE" "/Applications/KiCad/KiCad.app/Contents/Applications/pcbnew.app"
 
 mkdir -p /usr/local/bin
 


### PR DESCRIPTION
KiKit 7 on Mac uses Python 3.9 instead of 3.8. (Why not newer? Anyhoo.) The Mac installer script defaulted to 3.8 but now picks the version automatically.

Also support command-line options for installing KiKit "in-place", or as editable or for defining a non-standard KiCad installation location.