### PR TITLE
Add support for collections in closestIntersectionPoint

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -1338,7 +1338,7 @@ class Panel:
         for cut in cuts:
             if len(cut.simplify(SHP_EPSILON).coords) > 2 and not boundCurves:
                 raise RuntimeError("Cannot V-Cut a curve")
-            cut = cut.parallel_offset(offset, "left")
+            cut = cut.simplify(1).parallel_offset(offset, "left")
             start = roundPoint(cut.coords[0])
             end = roundPoint(cut.coords[-1])
             if start.x == end.x or (abs(start.x - end.x) <= fromMm(0.5) and boundCurves):

--- a/kikit/substrate.py
+++ b/kikit/substrate.py
@@ -408,20 +408,6 @@ def biteBoundary(boundary, pointA, pointB, tolerance=fromMm(0.01)):
     return None
 
 
-def collectionToPointList(collection):
-    geoms = list()
-    for geom in collection:
-        if isinstance(geom, Point):
-            geoms.append(geom)
-        elif isinstance(geom, LineString):
-            # When a linestring is an intersection, we know that the starting or
-            # ending points are the nearest one
-            geoms.extend([Point(geom.coords[0]), Point(geom.coords[-1])])
-        else:
-            raise TypeError(f"intersection() returned an unsupported datatype: {geom.__class__.__name__}")
-    return geoms
-
-
 def closestIntersectionPoint(origin, direction, outline, maxDistance):
     """Find the closest intersection between an outline from a point within a maximum distance under a given direction"""
     testLine = LineString([origin, origin + direction * maxDistance])
@@ -438,10 +424,16 @@ def closestIntersectionPoint(origin, direction, outline, maxDistance):
             plt.show()
         raise NoIntersectionError(f"No intersection found within given distance", origin)
     origin = Point(origin[0], origin[1])
-    if hasattr(inter, '__iter__'):
-        geoms = collectionToPointList(inter)
-    else:
-        geoms = collectionToPointList([inter])
+    geoms = list()
+    for geom in listGeometries(inter):
+        if isinstance(geom, Point):
+            geoms.append(geom)
+        elif isinstance(geom, LineString):
+            # When a linestring is an intersection, we know that the starting or
+            # ending points are the nearest one
+            geoms.extend([Point(geom.coords[0]), Point(geom.coords[-1])])
+        else:
+            raise TypeError(f"intersection() returned an unsupported datatype: {geom.__class__.__name__}")
     return min([(g, origin.distance(g)) for g in geoms], key=lambda t: t[1])[0]
 
 def linestringToKicad(linestring):

--- a/kikit/substrate.py
+++ b/kikit/substrate.py
@@ -417,6 +417,8 @@ def collectionToPointList(collection):
             # When a linestring is an intersection, we know that the starting or
             # ending points are the nearest one
             geoms.extend([Point(geom.coords[0]), Point(geom.coords[-1])])
+        else:
+            raise TypeError(f"intersection() returned an unsupported datatype: {geom.__class__.__name__}")
     return geoms
 
 

--- a/kikit/substrate.py
+++ b/kikit/substrate.py
@@ -408,6 +408,18 @@ def biteBoundary(boundary, pointA, pointB, tolerance=fromMm(0.01)):
     return None
 
 
+def collectionToPointList(collection):
+    geoms = list()
+    for geom in collection:
+        if isinstance(geom, Point):
+            geoms.append(geom)
+        elif isinstance(geom, LineString):
+            # When a linestring is an intersection, we know that the starting or
+            # ending points are the nearest one
+            geoms.extend([Point(geom.coords[0]), Point(geom.coords[-1])])
+    return geoms
+
+
 def closestIntersectionPoint(origin, direction, outline, maxDistance):
     """Find the closest intersection between an outline from a point within a maximum distance under a given direction"""
     testLine = LineString([origin, origin + direction * maxDistance])
@@ -424,14 +436,10 @@ def closestIntersectionPoint(origin, direction, outline, maxDistance):
             plt.show()
         raise NoIntersectionError(f"No intersection found within given distance", origin)
     origin = Point(origin[0], origin[1])
-    if isinstance(inter, Point):
-        geoms = [inter]
-    elif isinstance(inter, LineString):
-        # When a linestring is an intersection, we know that the starting or
-        # ending points are the nearest one
-        geoms = [Point(inter.coords[0]), Point(inter.coords[-1])]
+    if hasattr(inter, '__iter__'):
+        geoms = collectionToPointList(inter)
     else:
-        geoms = inter.geoms
+        geoms = collectionToPointList([inter])
     return min([(g, origin.distance(g)) for g in geoms], key=lambda t: t[1])[0]
 
 def linestringToKicad(linestring):


### PR DESCRIPTION
See https://github.com/yaqwsx/KiKit/issues/521 for full context.

This adds support to `substrate.closestIntersectionPoint()` for when `testLine.intersection()` returns a collection with `LineString`s in in.