### PR TITLE
Prepend library names in AnnotationReader.getDefault() to be compatible with KiCAD 7.0

### DIFF
--- a/kikit/annotations.py
+++ b/kikit/annotations.py
@@ -104,8 +104,15 @@ class AnnotationReader:
 
     @staticmethod
     def getDefault() -> AnnotationReader:
+        """
+        Return AnnotationReader object initialized with default annotations registered
+        """
         r = AnnotationReader()
         r.registerTab("kikit", "Tab")
         r.registerBoard("kikit", "Board")
+
+        # Since KiCAD 7.0 the plugins installed via the Plugin and Content Manager get prepended with `PCM_`
+        r.registerTab("PCM_kikit", "Tab")
+        r.registerBoard("PCM_kikit", "Board")
         return r
 


### PR DESCRIPTION
Since KiCAD 7.0 library names from plugins installed via the Plugin and Content Manager (PCM) get prepended with `PCM_`. In order to make tab annotations work with KiCAD 7.0 the library names in `AnnotationReader.getDefault()` need to be also prepended with that string.