### PR TITLE
Configured CLI to allow 'manual' option for layout.

### DIFF
--- a/kikit/plugin.py
+++ b/kikit/plugin.py
@@ -3,6 +3,7 @@
 # 'plugin'. In order not to break the existing PCM installations we import this
 # and leave it here for at least a couple of months to ensure that everybody
 # upgrades to a new PCM package.
+from pcbnew import VECTOR2I
 from kikit.actionPlugins import importAllPlugins # type: ignore
 
 from typing import Any, Dict, Iterable
@@ -92,7 +93,7 @@ class LayoutPlugin:
     This type of plugin can create user specified board layouts
     """
     def __init__(self, preset: Preset, userArg: str, netPattern: str,
-                 refPattern: str, vspace: int, hspace: int, rotation: int) -> None:
+                 refPattern: str, vspace: int, hspace: int, rotation: int, destination: VECTOR2I) -> None:
         self.preset = preset
         self.userArg = userArg
         self.netPattern = netPattern
@@ -100,6 +101,7 @@ class LayoutPlugin:
         self.vspace = vspace
         self.hspace = hspace
         self.rotation = rotation
+        self.destination = destination
 
     def buildLayout(self, panel: Panel, inputFile: str,
                     sourceArea: pcbnew.BOX2I) -> Iterable[Substrate]:

--- a/kikit/resources/panelizePresets/default.json
+++ b/kikit/resources/panelizePresets/default.json
@@ -19,7 +19,10 @@
         "hbonecut": true,
         "baketext": true,
         "code": "none",
-        "arg": ""
+        "arg": "",
+        "destination": "[0, 0]",
+        "boards": "",
+        "locations": ""
     },
     "source": {
         "type": "auto",


### PR DESCRIPTION
This places additional boards at specified locations. Also added 'destination' option to layout, to specify the destination of the source board for all layout types.

New options for the 'manual' option are 'boards' and 'locations'. 
Both are lists, and could be changed to a dictionary or other format if that is preferred.

Tested the following:
- Grid layout with destination (need to use --post 'origin:' to see the effect)
- Manual layout with no additional boards
- Manual layout with multiple additional boards
- Manual layout but 'locations' and 'boards' options are different length (fails with message)
- Dump to preset file

Let me know if you have any questions, more to come.