### PR TITLE
Allow diferent BOMs on single panel

### DIFF
--- a/kikit/fab/common.py
+++ b/kikit/fab/common.py
@@ -162,8 +162,6 @@ def collectPosData(board, correctionFields, posFilter=lambda x : True,
     """
     if bom is None:
         bom = {}
-    else:
-        bom = { getReference(comp): comp for comp in bom }
 
     correctionPatterns = []
     if correctionFile is not None:

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -878,6 +878,18 @@ class Panel:
         if refRenamer is not None:
             renameRefs(board, lambda x: refRenamer(len(self.substrates), x))
 
+        for footprint in board.GetFootprints():
+            value = footprint.GetValue()
+            if '*' in value:
+                ref = footprint.Reference().GetText()
+
+                cnt = value.split('*')[1]
+                mod = len(self.substrates) % int(cnt)
+
+                if mod > 0:
+                    new_ref = "{}_{}".format(ref, mod + 1)
+                    footprint.Reference().SetText(new_ref)
+
         drawings = collectItems(board.GetDrawings(), enlargedSourceArea)
         footprints = collectFootprints(board.GetFootprints(), enlargedSourceArea)
         tracks = collectItems(board.GetTracks(), enlargedSourceArea)


### PR DESCRIPTION
this patch allows you to specify more BOM part numbers using multiple `field` parameters (--field LCSC,LCSC2) - they will get named {ref}, {ref}_2, ..., {ref}_n in bom file. You also need to specify how many variations there is per specific component by configuring the component value to `{value}*{n}` where n {n} is the number of variations.

Crazy, stupid or genius? I don't know yet. 