### PR TITLE
Ngi0 reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # Ignore python files
 __pycache__
 

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/docs/assets/logo.png.license
+++ b/docs/assets/logo.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/3dstencil1.png.license
+++ b/docs/resources/3dstencil1.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/3dstencil2.jpg.license
+++ b/docs/resources/3dstencil2.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/conn-pcbnew.png.license
+++ b/docs/resources/conn-pcbnew.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/conn.png.license
+++ b/docs/resources/conn.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/connCK0NZ4.license
+++ b/docs/resources/connCK0NZ4.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/connI3qsNr.license
+++ b/docs/resources/connI3qsNr.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel1.png.license
+++ b/docs/resources/examplePanel1.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel10.png.license
+++ b/docs/resources/examplePanel10.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel11.png.license
+++ b/docs/resources/examplePanel11.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel12.png.license
+++ b/docs/resources/examplePanel12.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel13.png.license
+++ b/docs/resources/examplePanel13.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel14.png.license
+++ b/docs/resources/examplePanel14.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel15.png.license
+++ b/docs/resources/examplePanel15.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel16.png.license
+++ b/docs/resources/examplePanel16.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel17.png.license
+++ b/docs/resources/examplePanel17.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel18.png.license
+++ b/docs/resources/examplePanel18.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel19.png.license
+++ b/docs/resources/examplePanel19.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel2.png.license
+++ b/docs/resources/examplePanel2.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel20.png.license
+++ b/docs/resources/examplePanel20.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel21.png.license
+++ b/docs/resources/examplePanel21.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel22.png.license
+++ b/docs/resources/examplePanel22.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel23.png.license
+++ b/docs/resources/examplePanel23.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel24.png.license
+++ b/docs/resources/examplePanel24.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel25.png.license
+++ b/docs/resources/examplePanel25.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel26.png.license
+++ b/docs/resources/examplePanel26.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel3.png.license
+++ b/docs/resources/examplePanel3.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel4.png.license
+++ b/docs/resources/examplePanel4.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel5.png.license
+++ b/docs/resources/examplePanel5.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel6.png.license
+++ b/docs/resources/examplePanel6.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel7.png.license
+++ b/docs/resources/examplePanel7.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel8.png.license
+++ b/docs/resources/examplePanel8.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePanel9.png.license
+++ b/docs/resources/examplePanel9.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/examplePost.py.license
+++ b/docs/resources/examplePost.py.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/key-1.png.license
+++ b/docs/resources/key-1.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/key-2.png.license
+++ b/docs/resources/key-2.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/multiboardpcb.jpg.license
+++ b/docs/resources/multiboardpcb.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/multiboardsch.jpg.license
+++ b/docs/resources/multiboardsch.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/panelizeToolbar.png.license
+++ b/docs/resources/panelizeToolbar.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/panelizeWindow.png.license
+++ b/docs/resources/panelizeWindow.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/partition1.svg.license
+++ b/docs/resources/partition1.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/partition2.svg.license
+++ b/docs/resources/partition2.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/promo.jpg.license
+++ b/docs/resources/promo.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/promo.xcf.license
+++ b/docs/resources/promo.xcf.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/stencil1.jpg.license
+++ b/docs/resources/stencil1.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/stencil2.jpg.license
+++ b/docs/resources/stencil2.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/stencil3.jpg.license
+++ b/docs/resources/stencil3.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/stencil4.jpg.license
+++ b/docs/resources/stencil4.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/stencil5.jpg.license
+++ b/docs/resources/stencil5.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/tabdrawing.svg.license
+++ b/docs/resources/tabdrawing.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/tabdrawing1.png.license
+++ b/docs/resources/tabdrawing1.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/tabdrawing1.svg.license
+++ b/docs/resources/tabdrawing1.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/tabdrawing2.png.license
+++ b/docs/resources/tabdrawing2.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/tabdrawing2.svg.license
+++ b/docs/resources/tabdrawing2.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/tabdrawing3.png.license
+++ b/docs/resources/tabdrawing3.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/tabdrawing3.svg.license
+++ b/docs/resources/tabdrawing3.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/tabdrawing4.png.license
+++ b/docs/resources/tabdrawing4.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/tabdrawing4.svg.license
+++ b/docs/resources/tabdrawing4.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/tabdrawing5.svg.license
+++ b/docs/resources/tabdrawing5.svg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/windowsCommandPrompt1.jpg.license
+++ b/docs/resources/windowsCommandPrompt1.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/docs/resources/windowsCommandPrompt2.jpg.license
+++ b/docs/resources/windowsCommandPrompt2.jpg.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>

--- a/kikit/__init__.py
+++ b/kikit/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/kikit/_version.py
+++ b/kikit/_version.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
 
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag

--- a/kikit/actionPlugins/__init__.py
+++ b/kikit/actionPlugins/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from dataclasses import dataclass
 
 @dataclass

--- a/kikit/actionPlugins/common.py
+++ b/kikit/actionPlugins/common.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import wx
 import threading
 

--- a/kikit/actionPlugins/hideReferences.py
+++ b/kikit/actionPlugins/hideReferences.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from pcbnewTransition import pcbnew
 import wx
 import re

--- a/kikit/actionPlugins/panelize.py
+++ b/kikit/actionPlugins/panelize.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from sys import stderr
 from numpy.core.fromnumeric import std
 from numpy.lib.utils import source

--- a/kikit/annotations.py
+++ b/kikit/annotations.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 from typing import Dict, List, Set, Union
 import numpy as np

--- a/kikit/common.py
+++ b/kikit/common.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 import sys
 from typing import List, Optional, Tuple, Union, Callable

--- a/kikit/defs.py
+++ b/kikit/defs.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from enum import Enum, IntEnum
 from .units import mm, inch
 

--- a/kikit/doc.py
+++ b/kikit/doc.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import inspect
 import tempfile
 import subprocess

--- a/kikit/drc.py
+++ b/kikit/drc.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 import json

--- a/kikit/drc_ui.py
+++ b/kikit/drc_ui.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 from enum import Enum
 

--- a/kikit/eeschema.py
+++ b/kikit/eeschema.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 # Simple, rather hacky parser for eeshema files (.sch). This is a mid-term
 # workaround before proper support for scripting is introduced into Eeschema
 

--- a/kikit/eeschema_v6.py
+++ b/kikit/eeschema_v6.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from dataclasses import dataclass, field
 from kikit.sexpr import Atom, parseSexprF
 from itertools import islice

--- a/kikit/export.py
+++ b/kikit/export.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 # Based on https://github.com/KiCad/kicad-source-mirror/blob/master/demos/python_scripts_examples/gen_gerber_and_drill_files_board.py
 import sys
 import os

--- a/kikit/export_ui.py
+++ b/kikit/export_ui.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 
 @click.group()

--- a/kikit/fab/__init__.py
+++ b/kikit/fab/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT

--- a/kikit/fab/common.py
+++ b/kikit/fab/common.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import csv
 from dataclasses import dataclass
 import re

--- a/kikit/fab/jlcpcb.py
+++ b/kikit/fab/jlcpcb.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 from pcbnewTransition import pcbnew
 import csv

--- a/kikit/fab/oshpark.py
+++ b/kikit/fab/oshpark.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from pcbnewTransition import pcbnew
 import os
 import shutil

--- a/kikit/fab/pcbway.py
+++ b/kikit/fab/pcbway.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 from pcbnewTransition import pcbnew
 import csv

--- a/kikit/fab_ui.py
+++ b/kikit/fab_ui.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import traceback
 import sys
 import click

--- a/kikit/info.py
+++ b/kikit/info.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
 
 from pcbnewTransition import KICAD_VERSION, isV6, isV7
 from kikit.common import KIKIT_LIB

--- a/kikit/intervals.py
+++ b/kikit/intervals.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 import typing
 from typing import Any, Dict, List, Optional, Union, Tuple, Callable, Iterable

--- a/kikit/kicadUtil.py
+++ b/kikit/kicadUtil.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from typing import Tuple
 from .common import KiLength
 from .units import mm

--- a/kikit/modify.py
+++ b/kikit/modify.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from typing import Set
 from pcbnewTransition import pcbnew
 from .defs import Layer

--- a/kikit/modify_ui.py
+++ b/kikit/modify_ui.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 
 @click.command()

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from copy import deepcopy
 import itertools
 from pcbnewTransition import pcbnew, isV6

--- a/kikit/panelize_ui.py
+++ b/kikit/panelize_ui.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 import os
 import csv

--- a/kikit/panelize_ui_impl.py
+++ b/kikit/panelize_ui_impl.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from kikit import panelize
 from kikit.panelize_ui import Section, PresetError
 from kikit.panelize import *

--- a/kikit/panelize_ui_sections.py
+++ b/kikit/panelize_ui_sections.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from dataclasses import dataclass
 import os
 from typing import Any, List

--- a/kikit/plugin.py
+++ b/kikit/plugin.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 # This has nothing to do with KiKit plugins, instead, it is the registration
 # routine for Action plugins. However, the original implementation used the name
 # 'plugin'. In order not to break the existing PCM installations we import this

--- a/kikit/present.py
+++ b/kikit/present.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 from pathlib import Path
 import sys

--- a/kikit/present_ui.py
+++ b/kikit/present_ui.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 
 @click.command()

--- a/kikit/sexpr.py
+++ b/kikit/sexpr.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from io import StringIO
 from typing import Callable, Dict, Iterable, Optional, Union
 

--- a/kikit/stencil.py
+++ b/kikit/stencil.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from pcbnewTransition import pcbnew
 import numpy as np
 import json

--- a/kikit/stencil_ui.py
+++ b/kikit/stencil_ui.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 import sys
 

--- a/kikit/substrate.py
+++ b/kikit/substrate.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from shapely import geometry
 from shapely.geometry import (Polygon, MultiPolygon, LineString,
     MultiLineString, LinearRing, Point)

--- a/kikit/text.py
+++ b/kikit/text.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import datetime as dt
 from string import Template
 from typing import Callable, Optional, Dict, Any

--- a/kikit/typing.py
+++ b/kikit/typing.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 from abc import abstractmethod
 from typing import Tuple, TypeVar, Protocol

--- a/kikit/ui.py
+++ b/kikit/ui.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 from kikit import (panelize_ui, export_ui, present_ui, stencil_ui,
     modify_ui, fab_ui, drc_ui)

--- a/kikit/units.py
+++ b/kikit/units.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import re
 import math
 from pcbnewTransition import pcbnew

--- a/scripts/exampleDoc.py
+++ b/scripts/exampleDoc.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 """
 Generate documentation in markdown format for examples
 """

--- a/scripts/exampleScripting.py
+++ b/scripts/exampleScripting.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 """
 Generate previews of the available scripts
 """

--- a/scripts/installMacOS.bash
+++ b/scripts/installMacOS.bash
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 set -e -u
 
 if [ "$EUID" -ne 0 ]

--- a/scripts/panelizeDoc.py
+++ b/scripts/panelizeDoc.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 """
 Generate documentation in markdown format for panelization
 """

--- a/scripts/registerPlugin.sh
+++ b/scripts/registerPlugin.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env sh
 
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 echo "import kikit.plugin" > ~/.kicad_plugins/kikit_plugin.py

--- a/scripts/setJson.py
+++ b/scripts/setJson.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2023 Jan Mrázek <email@honzamrazek.cz>
+#
+# SPDX-License-Identifier: MIT
+
 import click
 import json
 from collections import OrderedDict


### PR DESCRIPTION
Hello,

By way of introduction, I am Jithendra with the Free Software Foundation Europe, a consortium member of the NGI0 Initiative, of which you have signed KiKit up for participation and funding. Part of what is offered with your involvement with NGI0 is help from us with your project on your copyright and license management.

After a quick check on your repository, I would like to propose some updates regarding copyright and licensing information in your files. Our REUSE specification (https://reuse.software/) intends to make licensing easier with best practices to display legal information through comment headers on source files that can be easily human and machine readable. The REUSE tool makes the process of applying licenses to files and compliance checking much easier.

Instructions on how to install the REUSE tool can be found here: https://reuse.readthedocs.io/en/stable/readme.html#install

You can also check out this screencast for more instructions on how to use the REUSE tool: https://download.fsfe.org/videos/reuse/screencasts/reuse-tool.gif

The changes in this pull request have also been made for you to understand the basic ideas behind REUSE, and how adopting the REUSE practices would look like within your repository.

# REUSE Features:

• SPDX copyright and license comment headers for relevant files.
• LICENSES directory with licenses used in the repository
• Associating copyright/licensing information through a DEP5 file in large directories.
Files Missing Copyright and Licensing Information
I've noticed that several files in your repository already contain information about the copyright and license information for the code in that particular file. That's great! Nevertheless, the idea behind REUSE is that every single file in your repository should have a header that includes this information.

To serve as an example, I added the SPDX headers with copyright and license information to the copyrightable files in a few of the directories (namely all the ".py" files in the scripts and kikit folders). This should give you an idea of how comment headers should look like in a REUSE compliant repository, and how they should be added to the other source code files in your repository.

Please also check if the personal information in these headers are correct and consistent to your knowledge. In the event that there are more copyright holders, please include them in these comment headers.
LICENSES Directory in the Root of the Project Repository

The LICENSES Folder should contain the license text of every license applicable in your repository. I included in this directory the file that contained the MIT and CC0 licenses.

Additionally, I included in this folder the text for the CC0 license. This is because you have files in your project that are not copyrightable, for example configuration files such as .gitignore. As the fundamental idea of REUSE is that all of your files will clearly have their copyright and licensing marked, I have applied the CC0 license to .gitignore, which is functionally identical to putting the file into the public domain.

## Image Files

Additionally, I noticed that you have two image files ".png and .jpg" in the assets and resources folders. For image files, we recommend creating a .license file, where you can include the comment headers for the license and copyright information. We've added comment headers to all the .png and.jpg files in images folder and listed the project Jan Mrázek as the copyright holder. Please feel free to modify and update this to your needs.

I hope that you find this useful. Feel free to adopt in case you feel REUSE may help your project with copyright and licensing management. Please feel free to contact me directly at [jithendra@fsfe.org](mailto:jithendra@fsfe.org) if you have any questions.

Best,
Jithendra
(Free Software Foundation Europe)