### PR TITLE
Support merging multiple schematics for fab output

### DIFF
--- a/kikit/fab/jlcpcb.py
+++ b/kikit/fab/jlcpcb.py
@@ -9,24 +9,9 @@ from kikit.fab.common import *
 from kikit.common import *
 from kikit.export import gerberImpl
 
-def collectBom(components, lscsFields, ignore):
+def collectBom(components, lscsFields):
     bom = {}
     for c in components:
-        if getUnit(c) != 1:
-            continue
-        reference = getReference(c)
-        if reference.startswith("#PWR") or reference.startswith("#FL"):
-            continue
-        if reference in ignore:
-            continue
-        if getField(c, "JLCPCB_IGNORE") is not None and getField(c, "JLCPCB_IGNORE") != "":
-            continue
-        if hasattr(c, "in_bom") and not c.in_bom:
-            continue
-        if hasattr(c, "on_board") and not c.on_board:
-            continue
-        if hasattr(c, "dnp") and c.dnp:
-            continue
         orderCode = None
         for fieldName in lscsFields:
             orderCode = getField(c, fieldName)
@@ -37,7 +22,7 @@ def collectBom(components, lscsFields, ignore):
             getField(c, "Footprint"),
             orderCode
         )
-        bom[cType] = bom.get(cType, []) + [reference]
+        bom[cType] = bom.get(cType, []) + [getReference(c)]
     return bom
 
 def bomToCsv(bomData, filename):
@@ -85,9 +70,9 @@ def exportJlcpcb(board, outputdir, assembly, schematic, ignore, field,
     ensureValidSch(schematic)
 
     correctionFields = [x.strip() for x in corrections.split(",")]
-    components = extractComponents(schematic)
+    components = extractComponents(schematic, refsToIgnore, "JLCPCB_IGNORE")
     ordercodeFields = [x.strip() for x in field.split(",")]
-    bom = collectBom(components, ordercodeFields, refsToIgnore)
+    bom = collectBom(components, ordercodeFields)
 
     posData = collectPosData(loadedBoard, correctionFields,
         bom=components, posFilter=noFilter, correctionFile=correctionpatterns)

--- a/kikit/fab/neodenyy1.py
+++ b/kikit/fab/neodenyy1.py
@@ -18,27 +18,14 @@ FOOTPRIINTREGEX = {
     re.compile(r'Crystal:Crystal_SMD_(.*?)_.*'): 'CRYSTAL_{}'
 }
 
-def collectBom(components, ignore):
+def collectBom(components):
     bom = {}
     for c in components:
-        if getUnit(c) != 1:
-            continue
-        reference = getReference(c)
-        if reference.startswith("#PWR") or reference.startswith("#FL"):
-            continue
-        if reference in ignore:
-            continue
-        if hasattr(c, "in_bom") and not c.in_bom:
-            continue
-        if hasattr(c, "on_board") and not c.on_board:
-            continue
-        if hasattr(c, "dnp") and c.dnp:
-            continue
         cType = (
             getField(c, "Value"),
             getField(c, "Footprint")
         )
-        bom[cType] = bom.get(cType, []) + [reference]
+        bom[cType] = bom.get(cType, []) + [getReference(c)]
     return bom
 
 def transcodeFootprint(footprint):
@@ -146,8 +133,8 @@ def exportNeodenYY1(board, outputdir, schematic, ignore,
     ensureValidSch(schematic)
 
     correctionFields = [x.strip() for x in corrections.split(",")]
-    components = extractComponents(schematic)
-    bom = collectBom(components, refsToIgnore)
+    components = extractComponents(schematic, refsToIgnore, "NEODENYY1_IGNORE")
+    bom = collectBom(components)
 
     posData = collectPosData(loadedBoard, correctionFields,
         bom=components, posFilter=noFilter, correctionFile=correctionpatterns)

--- a/kikit/fab_ui.py
+++ b/kikit/fab_ui.py
@@ -37,7 +37,8 @@ def execute(fab, kwargs):
 @click.command()
 @fabCommand
 @click.option("--assembly/--no-assembly", help="Generate files for SMT assembly (schematics is required)")
-@click.option("--schematic", type=click.Path(dir_okay=False), help="Board schematics (required for assembly files)")
+@click.option("--schematic", type=click.Path(dir_okay=False), multiple=True,
+    help="Board schematics (required for assembly files, can be specified more than once to merge components from multiple schematics)")
 @click.option("--ignore", type=str, default="", help="Comma separated list of designators to exclude from SMT assembly")
 @click.option("--field", type=str, default="LCSC",
     help="Comma separated list of component fields field with LCSC order code. First existing field is used")
@@ -57,7 +58,8 @@ def jlcpcb(**kwargs):
 @click.command()
 @fabCommand
 @click.option("--assembly/--no-assembly", help="Generate files for SMT assembly (schematics is required)")
-@click.option("--schematic", type=click.Path(dir_okay=False), help="Board schematics (required for assembly files)")
+@click.option("--schematic", type=click.Path(dir_okay=False), multiple=True,
+    help="Board schematics (required for assembly files, can be specified more than once to merge components from multiple schematics)")
 @click.option("--ignore", type=str, default="", help="Comma separated list of designators to exclude from SMT assembly")
 @click.option("--corrections", type=str, default="PCBWAY_CORRECTION",
     help="Comma separated list of component fields with the correction value. First existing field is used")
@@ -100,7 +102,8 @@ def oshpark(**kwargs):
 
 @click.command()
 @fabCommand
-@click.option("--schematic", type=click.Path(dir_okay=False), help="Board schematics (required for assembly files)")
+@click.option("--schematic", type=click.Path(dir_okay=False), multiple=True,
+    help="Board schematics (required for assembly files, can be specified more than once to merge components from multiple schematics)")
 @click.option("--ignore", type=str, default="", help="Comma separated list of designators to exclude from SMT assembly")
 @click.option("--corrections", type=str, default="YY1_CORRECTION",
     help="Comma separated list of component fields with the correction value. First existing field is used")


### PR DESCRIPTION
I want to be able to panelize boards from multiple different projects together in the same panel. This is an open feature request elsewhere, but for my purposes I just implemented a simple layout plugin to handle it. The plug in API is nice!

However for "fab --assembly" to work I also need to be able to merge the schematics for each board. This PR allows the user to specify the "--schematic" argument multiple times, and all components will be merged from each schematic.

For this to work, the reference designators must be unique across all schematics and I added validation to check that. Currently I think duplicate references are happily added to the BOM. This requirement could be relaxed if UUIDs were used to correlate components and reference designators were renamed to be unique for each board, however I think that would confuse both users and fabricators pretty fast. And it's pretty easy to have unique references by just setting the starting index for generating them to different values for each project.

If this is too much of a hack, feel free to close. I also de-duplicated the code that filters parts out of the BOM to make the uniqueness check work more nicely.