### PR TITLE
Add 'solderMaskMargin' parameter to Tooling

### DIFF
--- a/docs/panelization/cli.md
+++ b/docs/panelization/cli.md
@@ -416,6 +416,7 @@ by
 - `size` - diameter of the holes
 - `paste` - if true, the holes are included in the paste layer (therefore they
   appear on the stencil).
+- `solderMaskMargin` - diameter of solder mask (optional)
 
 #### Plugin
 

--- a/docs/panelization/python_api.md
+++ b/docs/panelization/python_api.md
@@ -124,13 +124,15 @@ None
 #### `addCornerTooling`
 ```
 addCornerTooling(self, holeCount, horizontalOffset, verticalOffset, diameter, 
-                 paste=False)
+                 paste=False, solderMaskMargin=None)
 ```
 Add up to 4 tooling holes to the top-left, top-right, bottom-left and
 bottom-right corner of the board (in this order). This function expects
 there is enough space on the board/frame/rail to place the feature.
 
 The offsets are measured from the outer edges of the substrate.
+
+Optionally, a solder mask margin (diameter) can also be specified.
 
 #### `addFiducial`
 ```

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -1513,7 +1513,9 @@ class Panel:
 
     def addNPTHole(self, position: VECTOR2I, diameter: KiLength,
                    paste: bool=False, ref: Optional[str]=None,
-                   excludedFromPos: bool=False) -> None:
+                   excludedFromPos: bool=False,
+                   solderMaskMargin: Optional[KiLength] = None,
+    ) -> None:
         """
         Add a drilled non-plated hole to the position (`VECTOR2I`) with given
         diameter. The paste option allows to place the hole on the paste layers.
@@ -1523,6 +1525,8 @@ class Panel:
         for pad in footprint.Pads():
             pad.SetDrillSize(toKiCADPoint((diameter, diameter)))
             pad.SetSize(toKiCADPoint((diameter, diameter)))
+            if solderMaskMargin is not None:
+                footprint.SetLocalSolderMaskMargin(solderMaskMargin)
             if paste:
                 layerSet = pad.GetLayerSet()
                 layerSet.AddLayer(Layer.F_Paste)
@@ -1595,7 +1599,7 @@ class Panel:
                              paste, ref = f"KiKit_FID_B_{i+1}")
 
     def addCornerTooling(self, holeCount, horizontalOffset, verticalOffset,
-                         diameter, paste=False):
+                         diameter, paste=False, solderMaskMargin: Optional[KiLength]=None):
         """
         Add up to 4 tooling holes to the top-left, top-right, bottom-left and
         bottom-right corner of the board (in this order). This function expects
@@ -1604,7 +1608,8 @@ class Panel:
         The offsets are measured from the outer edges of the substrate.
         """
         for i, pos in enumerate(self.panelCorners(horizontalOffset, verticalOffset)[:holeCount]):
-            self.addNPTHole(pos, diameter, paste, ref=f"KiKit_TO_{i+1}", excludedFromPos=False)
+            self.addNPTHole(pos, diameter, paste, ref=f"KiKit_TO_{i+1}", excludedFromPos=False,
+                            solderMaskMargin=solderMaskMargin)
 
     def addMillFillets(self, millRadius):
         """

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -1606,6 +1606,8 @@ class Panel:
         there is enough space on the board/frame/rail to place the feature.
 
         The offsets are measured from the outer edges of the substrate.
+
+        Optionally, a solder mask margin (diameter) can also be specified.
         """
         for i, pos in enumerate(self.panelCorners(horizontalOffset, verticalOffset)[:holeCount]):
             self.addNPTHole(pos, diameter, paste, ref=f"KiKit_TO_{i+1}", excludedFromPos=False,

--- a/kikit/panelize_ui_impl.py
+++ b/kikit/panelize_ui_impl.py
@@ -501,11 +501,12 @@ def buildTooling(preset, panel):
         hoffset, voffset = toolingPreset["hoffset"], toolingPreset["voffset"]
         diameter = toolingPreset["size"]
         paste = toolingPreset["paste"]
+        soldermaskmargin = toolingPreset["soldermaskmargin"]
         if type == "3hole":
-            panel.addCornerTooling(3, hoffset, voffset, diameter, paste)
+            panel.addCornerTooling(3, hoffset, voffset, diameter, paste, soldermaskmargin)
             return
         if type == "4hole":
-            panel.addCornerTooling(4, hoffset, voffset, diameter, paste)
+            panel.addCornerTooling(4, hoffset, voffset, diameter, paste, soldermaskmargin)
             return
         raise PresetError(f"Unknown type '{type}' of tooling specification.")
     except KeyError as e:

--- a/kikit/panelize_ui_sections.py
+++ b/kikit/panelize_ui_sections.py
@@ -540,6 +540,9 @@ TOOLING_SECTION = {
     "paste": SBool(
         typeIn(["3hole", "4hole", "plugin"]),
         "Include holes on the paste layer"),
+    "soldermaskmargin": SLength(
+        typeIn(["3hole", "4hole", "plugin"]),
+        "Solder mask expansion/margin"),
     "code": SPlugin(
         plugin.ToolingPlugin,
         typeIn(["plugin"]),

--- a/kikit/resources/panelizePresets/default.json
+++ b/kikit/resources/panelizePresets/default.json
@@ -85,6 +85,7 @@
         "voffset": "0mm",
         "size": "2mm",
         "paste": false,
+        "soldermaskmargin": "0mm",
         "code": "none",
         "arg": ""
     },

--- a/kikit/resources/panelizePresets/jlcTooling.json
+++ b/kikit/resources/panelizePresets/jlcTooling.json
@@ -2,6 +2,7 @@
     "tooling": {
         "style": "3hole",
         "size": "1.152mm",
-        "paste": false
+        "paste": false,
+        "soldermaskmargin": "1.3mm"
     }
 }


### PR DESCRIPTION
JLCPCB's [public documentation](https://jlcpcb.com/help/article/47-How-to-add-tooling-holes-for-PCB-assembly-order) says tooling holes need to have a specific minimum solder mask expansion of 0.148mm. I couldn't find a way to easily specify this in KiKit though. I guess it's probably not that important or this would have been added earlier, but I thought it would be fun to do it anyway.