### PR TITLE
Fixed OddEvenRowsColumnsPosition placer rotation return type

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -56,11 +56,11 @@ class GridPlacerBase:
         """
         raise NotImplementedError("GridPlacerBase.position has to be overridden")
 
-    def rotation(self, i: int, j: int) -> int:
+    def rotation(self, i: int, j: int) -> KiAngle:
         """
         Given row and col coords of a board, return the orientation of the board
         """
-        return 0
+        return EDA_ANGLE(0, pcbnew.DEGREES_T)
 
 class BasicGridPosition(GridPlacerBase):
     """
@@ -93,8 +93,6 @@ class BasicGridPosition(GridPlacerBase):
                hbonecount * (self.hbonewidth + self.verSpace)
         return toKiCADPoint((xPos, yPos))
 
-    def rotation(self, i: int, j: int) -> KiAngle:
-        return EDA_ANGLE(0, pcbnew.DEGREES_T)
 
 class OddEvenRowsPosition(BasicGridPosition):
     """
@@ -120,7 +118,7 @@ class OddEvenRowsColumnsPosition(BasicGridPosition):
     """
     def rotation(self, i: int, j: int) -> KiAngle:
         if (i % 2) == (j % 2):
-            return 0
+            return EDA_ANGLE(0, pcbnew.DEGREES_T)
         return EDA_ANGLE(180, pcbnew.DEGREES_T)
 
 

--- a/test/units/test_panelize.py
+++ b/test/units/test_panelize.py
@@ -18,7 +18,7 @@ def test_grid_place_base_rotation():
 
 
 def test_basic_grid_position_rotation():
-    placer = GridPlacerBase()
+    placer = BasicGridPosition(0, 0)
     for (i, j) in ((0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)):
         rotation = placer.rotation(i, j)
         assert isinstance(rotation, KiAngle)

--- a/test/units/test_panelize.py
+++ b/test/units/test_panelize.py
@@ -1,7 +1,67 @@
 import pytest
-from kikit.panelize import prolongCut
+from pcbnewTransition.pcbnew import EDA_ANGLE, DEGREES_T
+from kikit.common import KiAngle
+from kikit.panelize import (
+    GridPlacerBase, BasicGridPosition, OddEvenRowsPosition,
+    OddEvenColumnPosition, OddEvenRowsColumnsPosition, prolongCut
+)
 from shapely.geometry import LineString
 from math import sqrt
+
+
+def test_grid_place_base_rotation():
+    placer = GridPlacerBase()
+    for (i, j) in ((0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)):
+        rotation = placer.rotation(i, j)
+        assert isinstance(rotation, KiAngle)
+        assert rotation.AsDegrees() == EDA_ANGLE(0, DEGREES_T).AsDegrees()
+
+
+def test_basic_grid_position_rotation():
+    placer = GridPlacerBase()
+    for (i, j) in ((0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)):
+        rotation = placer.rotation(i, j)
+        assert isinstance(rotation, KiAngle)
+        assert rotation.AsDegrees() == EDA_ANGLE(0, DEGREES_T).AsDegrees()
+
+
+def test_odd_even_rows_position_rotation():
+    placer = OddEvenRowsPosition(0, 0)
+    for (i, j, expected_rot) in ((0, 0, EDA_ANGLE(0, DEGREES_T)),
+                                 (0, 1, EDA_ANGLE(0, DEGREES_T)),
+                                 (1, 0, EDA_ANGLE(180, DEGREES_T)),
+                                 (1, 1, EDA_ANGLE(180, DEGREES_T)),
+                                 (2, 0, EDA_ANGLE(0, DEGREES_T)),
+                                 (2, 1, EDA_ANGLE(0, DEGREES_T))):
+        rotation = placer.rotation(i, j)
+        assert isinstance(rotation, KiAngle)
+        assert rotation.AsDegrees() == expected_rot.AsDegrees()
+
+
+def test_odd_even_column_position_rotation():
+    placer = OddEvenColumnPosition(0, 0)
+    for (i, j, expected_rot) in ((0, 0, EDA_ANGLE(0, DEGREES_T)),
+                                 (0, 1, EDA_ANGLE(180, DEGREES_T)),
+                                 (1, 0, EDA_ANGLE(0, DEGREES_T)),
+                                 (1, 1, EDA_ANGLE(180, DEGREES_T)),
+                                 (2, 0, EDA_ANGLE(0, DEGREES_T)),
+                                 (2, 1, EDA_ANGLE(180, DEGREES_T))):
+        rotation = placer.rotation(i, j)
+        assert isinstance(rotation, KiAngle)
+        assert rotation.AsDegrees() == expected_rot.AsDegrees()
+
+
+def test_odd_even_column_position_rotation():
+    placer = OddEvenRowsColumnsPosition(0, 0)
+    for (i, j, expected_rot) in ((0, 0, EDA_ANGLE(0, DEGREES_T)),
+                                 (0, 1, EDA_ANGLE(180, DEGREES_T)),
+                                 (1, 0, EDA_ANGLE(180, DEGREES_T)),
+                                 (1, 1, EDA_ANGLE(0, DEGREES_T)),
+                                 (2, 0, EDA_ANGLE(0, DEGREES_T)),
+                                 (2, 1, EDA_ANGLE(180, DEGREES_T))):
+        rotation = placer.rotation(i, j)
+        assert isinstance(rotation, KiAngle)
+        assert rotation.AsDegrees() == expected_rot.AsDegrees()
 
 
 def test_prolongCut():


### PR DESCRIPTION
Fixed rows/cols alternation bug. 
Added tests for placers `.rotation()` method.

Closes #658