### PR TITLE
Add an option to entirely skip components with missing LCSC field

### DIFF
--- a/kikit/fab_ui.py
+++ b/kikit/fab_ui.py
@@ -31,6 +31,7 @@ def fabCommand(f):
     help="Comma separated list of component fields with the correction value. First existing field is used")
 @click.option("--correctionpatterns", type=click.Path(dir_okay=False))
 @click.option("--missingError/--missingWarn", help="If a non-ignored component misses LCSC field, fail")
+@click.option("--skip-missing", is_flag=True, help="Skip components with missing or empty LCSC field")
 def jlcpcb(**kwargs):
     """
     Prepare fabrication files for JLCPCB including their assembly service


### PR DESCRIPTION
Leaving this up to discussion, since this functionality is already provided by the `JLCPCB_IGNORE`. It is just kinda annoying to fill those in in schematics where only a minority of components is populated by JLC.