### PR TITLE
VCUT Comments Layer

### DIFF
--- a/docs/panelization/cli.md
+++ b/docs/panelization/cli.md
@@ -344,6 +344,7 @@ Use mousebites to
   side without text.
 - `textprolongation` - the same as above, just on the text side
 - `textoffset` - offset of the text from the cut line
+- `textLayer` - layer for the text to appear (default Edge.Cuts)
 - `template` - a string template for text to render. Can contain variables
   listed below, e.g., `V-CUT {pos_mm}`.
     - `pos_mm`, `pos_inch` – position of the V-cut from the panel origin

--- a/docs/panelization/python_api.md
+++ b/docs/panelization/python_api.md
@@ -78,7 +78,7 @@ include components sticking out of the board outline, you can specify tolerance
 #### `appendBoard`
 ```
 appendBoard(self, filename, destination, sourceArea=None, origin=Origin.Center, 
-            rotationAngle=<pcbnew.EDA_ANGLE; proxy of <Swig Object of type 'EDA_ANGLE *' at 0x7f4b833f3120> >, 
+            rotationAngle=<pcbnew.EDA_ANGLE; proxy of <Swig Object of type 'EDA_ANGLE *' at 0x7f7695aaa610> >, 
             shrink=False, tolerance=0, bufferOutline=1000, netRenamer=None, 
             refRenamer=None, inheritDrc=True, interpretAnnotations=True, 
             bakeText=False)
@@ -168,7 +168,7 @@ given radius. This operation simulares milling.
 #### `addNPTHole`
 ```
 addNPTHole(self, position, diameter, paste=False, ref=None, 
-           excludedFromPos=False)
+           excludedFromPos=False, solderMaskMargin=None)
 ```
 Add a drilled non-plated hole to the position (`VECTOR2I`) with given
 diameter. The paste option allows to place the hole on the paste layers.
@@ -190,7 +190,7 @@ internal features of the board are not affected.
 #### `addText`
 ```
 addText(self, text, position, 
-        orientation=<pcbnew.EDA_ANGLE; proxy of <Swig Object of type 'EDA_ANGLE *' at 0x7f4b833f37b0> >, 
+        orientation=<pcbnew.EDA_ANGLE; proxy of <Swig Object of type 'EDA_ANGLE *' at 0x7f7695aab360> >, 
         width=1500000, height=1500000, thickness=300000, 
         hJustify=EDA_TEXT_HJUSTIFY_T.GR_TEXT_HJUSTIFY_CENTER, 
         vJustify=EDA_TEXT_VJUSTIFY_T.GR_TEXT_VJUSTIFY_CENTER, 
@@ -214,7 +214,7 @@ Adds a horizontal V-CUT at pos (integer in KiCAD units).
 #### `appendBoard`
 ```
 appendBoard(self, filename, destination, sourceArea=None, origin=Origin.Center, 
-            rotationAngle=<pcbnew.EDA_ANGLE; proxy of <Swig Object of type 'EDA_ANGLE *' at 0x7f4b833f3120> >, 
+            rotationAngle=<pcbnew.EDA_ANGLE; proxy of <Swig Object of type 'EDA_ANGLE *' at 0x7f7695aaa610> >, 
             shrink=False, tolerance=0, bufferOutline=1000, netRenamer=None, 
             refRenamer=None, inheritDrc=True, interpretAnnotations=True, 
             bakeText=False)
@@ -334,7 +334,7 @@ copperFillNonBoardAreas(self, clearance=1000000,
                         layers=[<Layer.F_Cu: 0>, <Layer.B_Cu: 31>], 
                         hatched=False, strokeWidth=1000000, 
                         strokeSpacing=1000000, 
-                        orientation=<pcbnew.EDA_ANGLE; proxy of <Swig Object of type 'EDA_ANGLE *' at 0x7f4b833f3510> >)
+                        orientation=<pcbnew.EDA_ANGLE; proxy of <Swig Object of type 'EDA_ANGLE *' at 0x7f7695aab450> >)
 ```
 This function is deprecated, please, use panel features instead.
 
@@ -401,6 +401,12 @@ getProFilepath(self, path=None)
 ```
 None
 
+#### `hasErrors`
+```
+hasErrors(self)
+```
+Report if panel has any non-fatal errors presents
+
 #### `inheritCopperLayers`
 ```
 inheritCopperLayers(self, board)
@@ -415,6 +421,12 @@ inheritDesignSettings(self, board)
 ```
 Inherit design settings from the given board specified by a filename or
 a board
+
+#### `inheritLayerNames`
+```
+inheritLayerNames(self, board)
+```
+None
 
 #### `inheritPageSize`
 ```
@@ -448,7 +460,7 @@ expandDist - the distance by which to expand the board outline in each direction
 
 #### `makeCutsToLayer`
 ```
-makeCutsToLayer(self, cuts, layer=Layer.Cmts_User, prolongation=0)
+makeCutsToLayer(self, cuts, layer=Layer.Cmts_User, prolongation=0, width=300000)
 ```
 Take a list of cuts and render them as lines on given layer. The cuts
 can be prolonged just like with mousebites.
@@ -480,9 +492,9 @@ minWidth - if the panel doesn't meet this width, it is extended
 
 minHeight - if the panel doesn't meet this height, it is extended
 
-maxWidth - if the panel doesn't meet this width, TooLargeError is raised
+maxWidth - if the panel doesn't meet this width, error is set and marked
 
-maxHeight - if the panel doesn't meet this height, TooLargeHeight is raised
+maxHeight - if the panel doesn't meet this height, error is set and marked
 
 #### `makeFrameCutsH`
 ```
@@ -499,7 +511,7 @@ Generate vertical cuts for the frame corners and return them
 #### `makeGrid`
 ```
 makeGrid(self, boardfile, sourceArea, rows, cols, destination, placer, 
-         rotation=<pcbnew.EDA_ANGLE; proxy of <Swig Object of type 'EDA_ANGLE *' at 0x7f4b833f3f00> >, 
+         rotation=<pcbnew.EDA_ANGLE; proxy of <Swig Object of type 'EDA_ANGLE *' at 0x7f7695aabb70> >, 
          netRenamePattern=Board_{n}-{orig}, refRenamePattern=Board_{n}-{orig}, 
          tolerance=0, bakeText=False)
 ```
@@ -585,7 +597,7 @@ makeRailsTb(self, thickness, minHeight=0, maxHeight=None)
 ```
 Adds a rail to top and bottom. You can specify minimal height the panel
 has to feature. You can also specify maximal height of the panel. If the
-height would be exceeded, TooLargeError is raised.
+height would be exceeded, error is set.
 
 #### `makeTightFrame`
 ```
@@ -609,9 +621,9 @@ minWidth - if the panel doesn't meet this width, it is extended
 
 minHeight - if the panel doesn't meet this height, it is extended
 
-maxWidth - if the panel doesn't meet this width, TooLargeError is raised
+maxWidth - if the panel doesn't meet this width, error is set
 
-maxHeight - if the panel doesn't meet this height, TooLargeHeight is raised
+maxHeight - if the panel doesn't meet this height, error is set
 
 #### `makeVCuts`
 ```
@@ -619,7 +631,7 @@ makeVCuts(self, cuts, boundCurves=False, offset=0)
 ```
 Take a list of lines to cut and performs V-CUTS. When boundCurves is
 set, approximate curved cuts by a line from the first and last point.
-Otherwise, raise an exception.
+Otherwise, make an approximate cut and report error.
 
 #### `panelBBox`
 ```
@@ -653,9 +665,15 @@ vfirst and hfirst are indices of the first backbone to render. They are
 
 Return a list of cuts
 
+#### `reportError`
+```
+reportError(self, position, message)
+```
+Reports a non-fatal error. The error is marked and rendered to the panel
+
 #### `save`
 ```
-save(self, reconstructArcs=False, refillAllZones=False)
+save(self, reconstructArcs=False, refillAllZones=False, edgeWidth=100000)
 ```
 Saves the panel to a file and makes the requested changes to the prl and
 pro files.
@@ -701,18 +719,6 @@ Set text properties cached in the board
 setTitleBlock(self, titleBlock)
 ```
 Set panel title block
-
-#### `setVCutClearance`
-```
-setVCutClearance(self, clearance)
-```
-Set V-cut clearance
-
-#### `setVCutLayer`
-```
-setVCutLayer(self, layer)
-```
-Set layer on which the V-Cuts will be rendered
 
 #### `transferProjectSettings`
 ```

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -464,6 +464,7 @@ class VCutSettings:
     textProlongation: KiLength = fromMm(3)
     layer: Layer = Layer.Cmts_User
     textTemplate: str = "V-CUT {pos_mm}"
+    textLayer: Layer = Layer.Cmts_User
     textOffset: KiLength = fromMm(3)
     clearance: KiLength = 0
 
@@ -1196,7 +1197,7 @@ class Panel:
             "pos_inv_inch": f"{(origin - position) / inch:.3f} mm",
         }
         label.SetText(self.vCutSettings.textTemplate.format(**variables))
-        label.SetLayer(self.vCutSettings.layer)
+        label.SetLayer(self.vCutSettings.textLayer)
         label.SetTextThickness(self.vCutSettings.textThickness)
         label.SetTextSize(toKiCADPoint((self.vCutSettings.textSize, self.vCutSettings.textSize)))
         label.SetHorizJustify(EDA_TEXT_HJUSTIFY_T.GR_TEXT_HJUSTIFY_LEFT)
@@ -1221,10 +1222,11 @@ class Panel:
                     bBox.GetY() + bBox.GetHeight())
             segments.append((segment, keepout))
 
-            label = pcbnew.PCB_TEXT(segment)
+            label = pcbnew.PCB_TEXT(self.board)
             self._setVCutLabelStyle(label, self.getAuxiliaryOrigin()[0], cut)
             label.SetPosition(toKiCADPoint((cut, minY - self.vCutSettings.textOffset)))
             label.SetTextAngle(fromDegrees(90))
+            #label.SetLayer(self.vCutSettings.textLayer)
             segments.append((label, None))
         return segments
 
@@ -1248,10 +1250,10 @@ class Panel:
                     cut + self.vCutSettings.clearance / 2)
             segments.append((segment, keepout))
 
-
-            label = pcbnew.PCB_TEXT(segment)
+            label = pcbnew.PCB_TEXT(self.board)
             self._setVCutLabelStyle(label, self.getAuxiliaryOrigin()[1], cut)
             label.SetPosition(toKiCADPoint((maxX + self.vCutSettings.textOffset, cut)))
+            #label.SetLayer(self.vCutSettings.textLayer)
             segments.append((label, None))
         return segments
 

--- a/kikit/panelize_ui_impl.py
+++ b/kikit/panelize_ui_impl.py
@@ -374,6 +374,7 @@ def makeCuts(properties, panel, cuts, ignoreOffset):
             panel.vCutSettings.textProlongation = properties["textprolongation"]
             panel.vCutSettings.endProlongation = properties["endprolongation"]
             panel.vCutSettings.textTemplate = properties["template"]
+            panel.vCutSettings.textLayer = properties["textLayer"]
             panel.vCutSettings.textOffset = properties["textoffset"]
 
         elif type == "mousebites":

--- a/kikit/panelize_ui_sections.py
+++ b/kikit/panelize_ui_sections.py
@@ -463,6 +463,9 @@ CUTS_SECTION = {
     "layer": SLayer(
         typeIn(["vcuts", "layer", "plugin"]),
         "Specify layer for the drawings"),
+    "textLayer": SLayer(
+        typeIn(["vcuts", "textLayer", "plugin"]),
+        "Specify layer for the text comments for the vcuts"),
     "code": SPlugin(
         plugin.CutsPlugin,
         typeIn(["plugin"]),

--- a/kikit/resources/panelizePresets/default.json
+++ b/kikit/resources/panelizePresets/default.json
@@ -57,6 +57,7 @@
         "textprolongation": "3mm",
         "textoffset": "3mm",
         "template": "V-CUT",
+        "textLayer": "Cmts.User",
         "layer": "Cmts.User",
         "offset": "0mm",
         "prolong": "0mm",

--- a/test/system/panelize.bats
+++ b/test/system/panelize.bats
@@ -19,6 +19,14 @@ load common
         --debug 'trace: true; deterministic: true' \
         $RES/conn.kicad_pcb panel_t1.kicad_pcb
 }
+@test "Simple grid, no space, vcuts, text template" {
+    kikit panelize \
+        --layout 'grid; rows: 2; cols: 2;' \
+        --tabs full \
+        --cuts 'vcuts; template: TEST-V-CUT {pos_mm}; templateLayer: F.Fab' \
+        --debug 'trace: true; deterministic: true' \
+        $RES/conn.kicad_pcb panel-vcut-template.kicad_pcb
+}
 
 @test "Simple grid, spacing, vcuts" {
     kikit panelize \


### PR DESCRIPTION
This allows the user to specify on which layer they would like VCUT text to appear. This could be a different layer from the actual cuts themselves.

TODO
It is added twice. I need help understanding the logic of the main panelize() to know how to exclude this. Line 608 of panelize is where it can possibly be added twice. Unsure if I should break out labels into a completely different function, or, try to pass in a parameter to help decide when to plot labels.