### PR TITLE
Handle correction offsets and rotation separately

### DIFF
--- a/kikit/fab/common.py
+++ b/kikit/fab/common.py
@@ -79,10 +79,7 @@ def layerToSide(layer):
 
 def footprintPosition(footprint, placeOffset, compensation):
     pos = footprint.GetPosition() - placeOffset
-    angle = -footprint.GetOrientation().AsRadians()
-    x = compensation[0] * cos(angle) - compensation[1] * sin(angle)
-    y = compensation[0] * sin(angle) + compensation[1] * cos(angle)
-    pos += VECTOR2I(fromMm(x), fromMm(y))
+    pos += VECTOR2I(fromMm(compensation[0]), fromMm(compensation[1]))
     return pos
 
 def footprintOrientation(footprint, compensation):


### PR DESCRIPTION
I ran into some very confusing/unintuitive behavior when setting both rotation and X/Y offsets on a component, and I think it's a bug, but please correct me if I'm wrong.

I have a PCB file where the rotation of a component is set to -90, and I noticed when uploading the position file for a PCBA job that it is off by 180 degrees from JLCPCB's library. I set the JLCPCB_CORRECTION field to `0;0;180` in my schematic to fix that, then went to update the X/Y offsets which were also offset. But because the component's rotation ended up being converted to 90 degrees this function effectively swapped X and Y, which is very confusing, especially when making changes to both X and Y at the same time.

I don't think it makes sense for the rotation angle to be taken into account when applying the X/Y correction fields here. Intuitively, I expect X and Y to be applied as is to the final positions regardless of the rotation, but let me know what you think