### PR TITLE
On KiCad 8.0.6 we can't just modify GetPosition() returned value

### DIFF
--- a/kikit/common.py
+++ b/kikit/common.py
@@ -315,7 +315,7 @@ def resolveAnchor(anchor):
     a VECTOR2I
     """
     choices = {
-        "tl": lambda x: x.GetPosition(),
+        "tl": lambda x: x.GetPosition() + toKiCADPoint((0, 0)),
         "tr": lambda x: x.GetPosition() + toKiCADPoint((x.GetWidth(), 0)),
         "bl": lambda x: x.GetPosition() + toKiCADPoint((0, x.GetHeight())),
         "br": lambda x: x.GetPosition() + toKiCADPoint((x.GetWidth(), x.GetHeight())),


### PR DESCRIPTION
Not at least adding a VECTORI2, so we need a copy. Adding (0, 0) does the work.
Seen with text objects.