### PR TITLE
Enhancement: Add Origin.AsSource to AppendBoard

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -144,6 +144,7 @@ class Origin(Enum):
     TopRight = 2
     BottomLeft = 3
     BottomRight = 4
+    FromSource = 5
 
 
 class NetClass():
@@ -185,6 +186,8 @@ def getOriginCoord(origin, bBox):
         return VECTOR2I(bBox.GetX(), bBox.GetY() + bBox.GetHeight())
     if origin == Origin.BottomRight:
         return VECTOR2I(bBox.GetX() + bBox.GetWidth(), bBox.GetY() + bBox.GetHeight())
+    if origin == Origin.AsSource:
+        return VECTOR2I(0,0)
 
 def appendItem(board: pcbnew.BOARD, item: pcbnew.BOARD_ITEM,
                yieldMapping: Optional[Callable[[str, str], None]]=None) -> None:


### PR DESCRIPTION
A very simple +3 lines that preserves the original coordinates of the board when importing.
We have found this very useful as we are scripting the penalisation of multi-board panels, and using coordinate systems and imported outlines generated form MCAD.

This change wont be useful for many people but just adds an extra option for those who need it.