### PR TITLE
[docs] Windows installation restart terminal test

### DIFF
--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -20,7 +20,7 @@ Then you have to enter the following command to install it:
 pip install kikit
 ```
 
-Now you can test that it works:
+After closing and re-opening "KiCAD Command Prompt", now you can test that it works:
 
 ```.bash
 kikit --help


### PR DESCRIPTION
Small docs fix to restart the terminal so that the path gets updated and `kikit --help` works.