### PR TITLE
Update windows.md with troubleshooting instructions

### DIFF
--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -46,5 +46,17 @@ Commands:
   stencil   Create solder paste stencils
 ```
 
+If you get an error message like the following:
+
+```
+> kikit --help
+'kikit' is not recognized as an internal or external command
+operable program or batch file.
+```
+
+... then you may need to close the terminal and re-open a new "KiCAD Command Prompt"
+so that it adds the plugin directory to the `%PATH%` variable. Then run `kikit --help`
+again, and you should see the help message shown above.
+
 Now you are done with the basic installation. Don't forget to get the GUI
 frontend and libraries via PCM.


### PR DESCRIPTION
The batch script that initializes paths in the command prompt enumerates existing directories only. Some plugin and script paths are only created after pip installs files that need to belong there. Thus, if KiKit is the first such plugin the user installs, the "test that it works" section will fail only because the CLI needs to be restarted to pick up the new paths.