### PR TITLE
Allow use of kicad-cli for KiKit present

### DIFF
--- a/docs/present.md
+++ b/docs/present.md
@@ -7,8 +7,11 @@ automatically generated panels.
 
 ## Requirements
 
-In order to include PCB drawings in presentations you will need to install
-[PcbDraw](https://github.com/yaqwsx/PcbDraw).
+In order to include PCB drawings in presentations you need one of the following:
+* Install[PcbDraw](https://github.com/yaqwsx/PcbDraw).
+* Install `kicad-cli` for KiCAD >= 9.0 and ImageMagick.
+
+To use `kicad-cli` for rendering, invoke `kikit present` with `--renderer kicad-cli`.
 
 ## Template name/path resolution
 

--- a/kikit/present_ui.py
+++ b/kikit/present_ui.py
@@ -12,6 +12,7 @@ import click
     help="Path to a template directory or a name of built-in one. See doc/present.md for template specification.")
 @click.option("--repository", type=str, help="URL of the repository")
 @click.option("--name", type=str, help="Name of the board (used e.g., for title)", required=True)
+@click.option("--renderer", type=str, default="pcbdraw", help="Choice of PCB image renderer (PcbDraw or kicad-cli)")
 def boardpage(**kwargs):
     """
     Build a board presentation page based on markdown description and include


### PR DESCRIPTION
The native kicad-cli now offers a way to render board images from the CLI . Since some users (including me) had some dependency issues with PcbDraw, this PR adds the option to use kicad-cli for board images by adding a `--renderer` switch to `kikit present`.

Kicad-cli is not perfect unfortunately, as there is no way currently to output appropriately sized images directly. As a workaround, this uses image magick to crop the images generated by KiCad.

Let me know if you're willing to upstream this and if there are any changes to make.