### PR TITLE
Fix jlcTooling preset

### DIFF
--- a/kikit/resources/panelizePresets/jlcTooling.json
+++ b/kikit/resources/panelizePresets/jlcTooling.json
@@ -1,6 +1,6 @@
 {
     "tooling": {
-        "style": "3hole",
+        "type": "3hole",
         "size": "1.152mm",
         "paste": false,
         "soldermaskmargin": "1.3mm"


### PR DESCRIPTION
I've noticed the preset didn't have any effect because "type" was misspelled as "style", and the code expects "type".