### PR TITLE
Allow to specify layer for annotation source

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -2410,18 +2410,18 @@ def getFootprintByReference(board, reference):
             return f
     raise RuntimeError(f"Footprint with reference '{reference}' not found")
 
-def extractSourceAreaByAnnotation(board, reference):
+def extractSourceAreaByAnnotation(board, reference, layer=Layer.Edge_Cuts):
     """
     Given a board and a reference to annotation in the form of symbol
     `kikit:Board`, extract the source area. The source area is a bounding box of
-    continuous lines in the Edge.Cuts on which the arrow in reference point.
+    continuous lines in the specified layer on which the arrow in reference point.
     """
     try:
         annotation = getFootprintByReference(board, reference)
     except Exception:
         raise RuntimeError(f"Cannot extract board - boards is specified via footprint with reference '{reference}' which was not found")
     tip = annotation.GetPosition()
-    edges = collectEdges(board, Layer.Edge_Cuts)
+    edges = collectEdges(board, layer)
     # KiCAD 6 will need an adjustment - method Collide was introduced with
     # different parameters. But v6 API is not available yet, so we leave this
     # to future ourselves.

--- a/kikit/panelize_ui_impl.py
+++ b/kikit/panelize_ui_impl.py
@@ -189,7 +189,8 @@ def readSourceArea(specification, board):
             ref = specification["ref"]
             if ref.strip() == "":
                 raise PresetError("When using source 'annotation' reference cannot be empty.")
-            return expandRect(extractSourceAreaByAnnotation(board, ref), tolerance)
+            layer = specification.get("layer", Layer.Edge_Cuts)
+            return expandRect(extractSourceAreaByAnnotation(board, ref, layer), tolerance)
         if type == "rectangle":
             tl = VECTOR2I(specification["tlx"], specification["tly"])
             br = VECTOR2I(specification["brx"], specification["bry"])

--- a/kikit/panelize_ui_sections.py
+++ b/kikit/panelize_ui_sections.py
@@ -359,6 +359,9 @@ SOURCE_SECTION = {
     "ref": SStr(
         typeIn(["annotation"]),
         "Specify reference of KiKit annotation symbol"),
+    "layer": SLayer(
+        typeIn(["annotation"]),
+        "Specify layer for annotation lines (default: Edge.Cuts)"),
     "stack": SChoice(
         ["inherit", "2layer", "4layer", "6layer"],
         always(),


### PR DESCRIPTION
When source consists of several isolated pieces, currently the way to select them is via the bounding box selection (the "rectangle" option). However it means the coordinates of the bounding box must be provided. This PR makes it possible to have a bounding box rectangle drawn on a user layer, and an annotation footprint pointing to that rectangle, to define the bounding box coordinates.
It also makes it possible to modify a single-piece source boundary without worrying the annotation doesn't point at its edge anymore.