### PR TITLE
Check if the panel file name includes directory and verify its existence

### DIFF
--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -511,6 +511,10 @@ class Panel:
         if not panelFilename.endswith(".kicad_pcb"):
             raise PanelError("Panel filename has to have .kicad_pcb suffix")
 
+        panelFileDirectory = os.path.dirname(panelFilename)
+        if panelFileDirectory and not os.path.isdir(panelFileDirectory):
+            raise PanelError(f"Output directory {panelFileDirectory} is not found")
+
         self.filename = panelFilename
         self.board = pcbnew.NewBoard(panelFilename)
         self.sourcePaths = set() # A set of all board files that were appended to the panel


### PR DESCRIPTION
Fix #850 

If specified panel file name includes a directory and if it is missing, the program aborts for an AttributeError.  This fix adds defensive code to let the user know the typo.