### PR TITLE
Fix tooling.solderMaskMargin

### DIFF
--- a/kikit/resources/kikit.pretty/NPTH.kicad_mod
+++ b/kikit/resources/kikit.pretty/NPTH.kicad_mod
@@ -5,5 +5,5 @@
   (fp_text value NPTH (at 0 -0.5) (layer F.Fab) hide
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (pad "" np_thru_hole circle (at 0 0) (size 1 1) (drill 1) (layers *.Mask))
+  (pad "" np_thru_hole circle (at 0 0) (size 1 1) (drill 1) (layers "F&B.Cu" "*.Mask"))
 )


### PR DESCRIPTION
[#689](https://github.com/yaqwsx/KiKit/issues/689)
This issue was closed as a KiCad bug fixed in v8, but it was still not working in KiCad v9.
The reason was that the pad was missing "F&B.Cu" Layers for the solder mask margin to take effect.
This fixes it for all versions.

Alternatively you could patch _panelize.py_ to add the Cu layers manually in `addNPTHole`, but fixing the footprint is easier.

Thanks for this project, really helped me alot!