### PR TITLE
WIP - use voronoi-diagram-for-polygons for partition lines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ setuptools.setup(
         "markdown2>=2.4",
         "pybars3>=0.9",
         "solidpython>=1.1.2",
-        "commentjson>=0.9"
+        "commentjson>=0.9",
+        "voronoi-diagram-for-polygons>=0.1.9",
     ],
     setup_requires=[
         "versioneer"


### PR DESCRIPTION
```bash
kikit panelize \
    --layout 'alternation: cols; vevendiff: 0mm; rotation: 90deg; rows: 2; cols: 2; baketext: False; hspace: -10mm; vspace: 10mm' \
    --tabs 'type: fixed' \
    --cuts 'type: mousebites' \
    --framing 'type: tightframe; hspace: 2mm; vspace: 2mm; width: 10mm' \
    l.kicad_pcb 'out.kicad_pcb' --debug 'drawPartitionLines: true' && pcbnew 'out.kicad_pcb
```

<img width="1140" height="1633" alt="image" src="https://github.com/user-attachments/assets/daffc255-a626-478e-b54b-15f2b9378f6f" />

This is a of some sort of proof of concept state at this point. I am not too familiar with kikit's internals but as far as I can tell the partition lines does seem to make some sense, right?

I think I might me missing something since the tabs on the left and right towards the panel are missing