### PR TITLE
KiCAD 10 changes

### DIFF
--- a/kikit/drc.py
+++ b/kikit/drc.py
@@ -212,7 +212,7 @@ def runBoardDrc(board: pcbnew.BOARD, strict: bool) -> DrcReport:
 
 def deserializeExclusion(exclusionText: str, board: pcbnew.BOARD) -> DrcExclusion:
     items = exclusionText.split("|")
-    objects = [board.GetItem(pcbnew.KIID(x)) for x in items[3:]]
+    objects = [board.ResolveItem(pcbnew.KIID(x)) for x in items[3:]]
     objects = [x for x in objects if x is not None]
     return DrcExclusion(items[0],
                         pcbnew.VECTOR2I(int(items[1]), int(items[2])),

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -1195,7 +1195,7 @@ class Panel:
             exclusions = readBoardDrcExclusions(board)
             for drcE in exclusions:
                 try:
-                    newObjects = [self.board.GetItem(pcbnew.KIID(itemMapping[x.m_Uuid.AsString()])) for x in drcE.objects]
+                    newObjects = [self.board.ResolveItem(pcbnew.KIID(itemMapping[x.m_Uuid.AsString()])) for x in drcE.objects]
                     assert all(x is not None for x in newObjects)
                     newPosition = doTransformation(drcE.position, rotationAngle, originPoint, translation)
                     self.drcExclusions.append(DrcExclusion(
@@ -2109,7 +2109,7 @@ class Panel:
         zone.SetIsRuleArea(True)
         zone.SetDoNotAllowTracks(noTracks)
         zone.SetDoNotAllowVias(noVias)
-        zone.SetDoNotAllowCopperPour(noCopper)
+        zone.SetDoNotAllowZoneFills(noCopper)
 
         zone.SetLayerSet(pcbnew.LSET.AllCuMask(self.copperLayerCount))
 

--- a/kikit/substrate.py
+++ b/kikit/substrate.py
@@ -684,7 +684,7 @@ class Substrate:
         elif isinstance(self.substrates, Polygon):
             geoms = [self.substrates]
         else:
-            raise RuntimeError("Uknown type '{}' of substrate geometry".format(type(self.substrates)))
+            raise RuntimeError("Unknown type '{}' of substrate geometry".format(type(self.substrates)))
         items = []
         for polygon in geoms:
             simplified_polygon = shapely.simplify(polygon, SHP_EPSILON)
@@ -812,7 +812,7 @@ class Substrate:
         elif isinstance(self.substrates, Polygon):
             geoms = [self.substrates]
         else:
-            raise RuntimeError("Uknown type '{}' of substrate geometry".format(type(self.substrates)))
+            raise RuntimeError("Unknown type '{}' of substrate geometry".format(type(self.substrates)))
         polygons = [Polygon(p.exterior) for p in geoms]
         return unary_union(polygons)
 

--- a/kikit/substrate.py
+++ b/kikit/substrate.py
@@ -807,7 +807,7 @@ class Substrate:
         """
         Return a geometry representing the substrate with no holes
         """
-        if isinstance(self.substrates, MultiPolygon):
+        if isinstance(self.substrates, MultiPolygon) or isinstance(self.substrates, GeometryCollection):
             geoms = self.substrates.geoms
         elif isinstance(self.substrates, Polygon):
             geoms = [self.substrates]


### PR DESCRIPTION
- `board.GetItem` -> `board.ResolveItem`
- `zone.SetDoNotAllowCopperPour` -> `zone.SetDoNotAllowZoneFills`
- Consistently handle `self.substrates` being a `GeometryCollection` (previously it was only handled  in one of two cases)
- Fix a typo in an error message