### PR TITLE
Expose KiKit properties from TabAnnotations

### DIFF
--- a/kikit/annotations.py
+++ b/kikit/annotations.py
@@ -44,7 +44,7 @@ class TabAnnotation(KiKitAnnotation):
         if "width" not in props:
             raise ValueError("Tab annotation must a KiKit annotation text with 'width' property defined")
         width = units.readLength(props["width"])
-        return TabAnnotation(footprint.GetReference(), origin, direction, width, props)
+        return TabAnnotation(footprint.GetReference(), origin, direction, width, props=props)
 
 class AnnotationReader:
     """

--- a/kikit/annotations.py
+++ b/kikit/annotations.py
@@ -27,12 +27,13 @@ class KiKitAnnotation:
     pass
 
 class TabAnnotation(KiKitAnnotation):
-    def __init__(self, ref, origin, direction, width, maxLength=fromMm(100)):
+    def __init__(self, ref, origin, direction, width, maxLength=fromMm(100), props={}):
         self.ref = ref
         self.origin = origin
         self.direction = direction
         self.width = width
         self.maxLength = maxLength
+        self.props = props
 
     @staticmethod
     def fromFootprint(footprint):
@@ -43,7 +44,7 @@ class TabAnnotation(KiKitAnnotation):
         if "width" not in props:
             raise ValueError("Tab annotation must a KiKit annotation text with 'width' property defined")
         width = units.readLength(props["width"])
-        return TabAnnotation(footprint.GetReference(), origin, direction, width)
+        return TabAnnotation(footprint.GetReference(), origin, direction, width, props)
 
 class AnnotationReader:
     """


### PR DESCRIPTION
The `AnnotationReader` has a lot of support for arguments from the user, but only width is used. To allow additional customization, this change passes the arguments into the `TabAnnotation` instance so that they may be used by the user to handle custom arguments in scripts.

An example usage -- in my panel I mix mouse bites and v-score breaks on my tabs. In order to differentiate where we can use v-cut and where we can use mousebites, I add an annotation to the tab, then parse it:
<img width="517" height="228" alt="image" src="https://github.com/user-attachments/assets/5018774a-36f9-4995-b467-b1a722727680" />
```python
p = panelize.Panel(PANEL_OUTPUT)
# ...
# Separate vcut annotations from drilled tab breaks
for s in p.substrates:
	s.annotations_vcut = [annotation for annotation in s.annotations if 'vcut' in annotation.props]
	s.annotations_drilled = [annotation for annotation in s.annotations if 'vcut' not in annotation.props]
	s.annotations = s.annotations_drilled
# Cut two types of annotations separately
drilled_cuts=p.buildTabsFromAnnotations(fillet=0*mm)
for s in p.substrates:
	s.annotations = s.annotations_vcut
vcut_cuts=p.buildTabsFromAnnotations(fillet=0*mm)
# For drilled cuts, add mouse bites
p.makeMouseBites(cuts=drilled_cuts)
# For V-cut annotations, add V-cuts
for cut in vcut_cuts:
	if cut.xy[0][0] == cut.xy[0][1]:
		p.addVCutV(cut.xy[0][0])
	elif cut.xy[1][0] == cut.xy[1][1]:
		p.addVCutH(cut.xy[1][0])
```

The resulting board can then mix tabs with mousebites and tabs with v-cuts depending on the desired post-processing.
<img width="1150" height="1240" alt="image" src="https://github.com/user-attachments/assets/d63a3a8d-ad5f-4895-b456-3eeff304e3d0" />
