### PR TITLE
Support for KiCad 10 native rounded rectangles

### DIFF
--- a/kikit/substrate.py
+++ b/kikit/substrate.py
@@ -257,6 +257,50 @@ def shapePolyToShapely(p: pcbnew.SHAPE_POLY_SET) \
     return MultiPolygon(polygons=polygons)
 
 
+def approximateRect(rect):
+    """
+    Take DRAWINGITEM rect and approximate it using lines. If it has a corner
+    radius (added in KiCad 10.0.0), approximate rounded corners with arcs.
+    """
+    corners = rect.GetRectCorners()
+    try:
+        radius = rect.GetCornerRadius()
+    except AttributeError:
+        radius = 0
+
+    if radius == 0:
+        return [tuple(x) for x in corners]
+
+    pts = [list(c) for c in corners]
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    min_x, max_x = min(xs), max(xs)
+    min_y, max_y = min(ys), max(ys)
+
+    SEGMENTS_PER_FULL = 4 * 32
+    segments = max(SEGMENTS_PER_FULL // 4, 12)
+
+    theta_tr = np.linspace(-np.pi/2, 0, segments)
+    x_tr = (max_x - radius) + radius * np.cos(theta_tr)
+    y_tr = (min_y + radius) + radius * np.sin(theta_tr)
+
+    theta_br = np.linspace(0, np.pi/2, segments)
+    x_br = (max_x - radius) + radius * np.cos(theta_br)
+    y_br = (max_y - radius) + radius * np.sin(theta_br)
+
+    theta_bl = np.linspace(np.pi/2, np.pi, segments)
+    x_bl = (min_x + radius) + radius * np.cos(theta_bl)
+    y_bl = (max_y - radius) + radius * np.sin(theta_bl)
+
+    theta_tl = np.linspace(np.pi, 3*np.pi/2, segments)
+    x_tl = (min_x + radius) + radius * np.cos(theta_tl)
+    y_tl = (min_y + radius) + radius * np.sin(theta_tl)
+
+    return (list(np.column_stack([x_tr, y_tr])) +
+            list(np.column_stack([x_br, y_br])) +
+            list(np.column_stack([x_bl, y_bl])) +
+            list(np.column_stack([x_tl, y_tl])))
+
 def toShapely(ring, geometryList):
     """
     Take a list of indices representing a ring from PCB_SHAPE entities and
@@ -274,7 +318,7 @@ def toShapely(ring, geometryList):
                 commonEndPoint(geometryList[idxA], geometryList[idxB]))
         elif shape in [STROKE_T.S_RECT]:
             assert idxA == idxB
-            outline += geometryList[idxA].GetRectCorners()
+            outline += approximateRect(geometryList[idxA])
         elif shape in [STROKE_T.S_POLYGON]:
             # Polygons are always closed, so they should appear as stand-alone
             assert len(ring) in [1, 2]

--- a/test/units/test_substrate.py
+++ b/test/units/test_substrate.py
@@ -21,3 +21,51 @@ def test_biteBoundary():
 
     t5 = biteBoundary(l1, Point(1, 0.25), Point(1, 0.75), 0.1)
     assert t5 == LineString([(1, 0.25), (1, 0.75)])
+
+import math
+
+class DummyRect:
+    def __init__(self, corners, radius=None):
+        self._corners = corners
+        self._radius = radius
+
+    def GetRectCorners(self):
+        return self._corners
+
+    def GetCornerRadius(self):
+        if self._radius is None:
+            raise AttributeError("no corner radius in old KiCad")
+        return self._radius
+
+def test_approximateRect_pre_kicad10():
+    # Pre-KiCad 10 has no corner radius attribute
+    rect = DummyRect([(0,0), (10,0), (10,5), (0,5)], radius=None)
+    points = approximateRect(rect)
+    assert points == [(0,0), (10,0), (10,5), (0,5)]
+
+def test_approximateRect_kicad10_radius_zero():
+    # KiCad 10 with corner radius explicitly 0
+    rect = DummyRect([(0,0), (10,0), (10,5), (0,5)], radius=0)
+    points = approximateRect(rect)
+    assert points == [(0,0), (10,0), (10,5), (0,5)]
+
+def test_approximateRect_kicad10_rounded():
+    # KiCad 10 Native rounded rectangle with radius 1
+    rect = DummyRect([(0,0), (10,0), (10,5), (0,5)], radius=1)
+    points = approximateRect(rect)
+    
+    assert len(points) > 4
+    
+    # Verify shape bounds
+    poly = Polygon(points)
+    assert poly.is_valid
+    
+    minx, miny, maxx, maxy = poly.bounds
+    assert pytest.approx(minx, rel=1e-3) == 0
+    assert pytest.approx(miny, rel=1e-3) == 0
+    assert pytest.approx(maxx, rel=1e-3) == 10
+    assert pytest.approx(maxy, rel=1e-3) == 5
+    
+    expected_area = 50 - (4 - math.pi * 1 * 1)
+    assert pytest.approx(poly.area, rel=1e-2) == expected_area
+


### PR DESCRIPTION
### PR Summary:
Adds support for KiCad 10 native rounded rectangles in `kikit.substrate.approximateRect()` while remaining backward compatible with previous versions of KiCad.

KiCad 10 introduced `PCB_SHAPE.GetCornerRadius()` for `gr_rect` PcbNew shapes. Previously, rectangles were always approximated by the 4 corner points of the bounding rect, which loses any new rounded geometry.

### Changes:
- `kikit/substrate.py`:
  - `approximateRect(rect)`:
    - reads `rect.GetRectCorners()`
    - attempts `rect.GetCornerRadius()`
    - if `GetCornerRadius()` exists and `radius > 0`:
      - builds per-corner arc points using `numpy.linspace` and `cos`/`sin`
      - returns a full rounded shape
    - if not supported or `radius == 0`:
      - returns existing 4-corner behavior
  - backward compatibility:
    - `try: radius = rect.GetCornerRadius()`
    - `except AttributeError: radius = 0`

- `test/units/test_substrate.py`:
  - added:
    - `test_approximateRect_pre_kicad10`
    - `test_approximateRect_kicad10_radius_zero`
    - `test_approximateRect_kicad10_rounded`
  - validates shape to expected corner count and approximate area.

### Notes:
- No behavior change for standard rectangles.
- New behavior is additive and opt-in on KiCad 10 rounded shapes.
- Testing
  - Installed and tested standard and rounded rectangle behavior in `KiCad 9.0.7` and `KiCad 10.0.0`.
  - Ran in KiCad Python environment:
    - `python -m pytest test/units/test_substrate.py`
    - Result: `4 passed`