### PR TITLE
fix: KiCad 10 API compatibility in drc.py and panelize.py

### DIFF
--- a/kikit/drc.py
+++ b/kikit/drc.py
@@ -21,14 +21,13 @@ def roundCoord(x: int) -> int:
     return round(x - 50, -4)
 
 def getItemDescription(item: pcbnew.BOARD_ITEM, units: pcbnew.EDA_UNITS = pcbnew.EDA_UNITS_MM):
-    if isV9():
-        uProvider = pcbnew.UNITS_PROVIDER(pcbnew.pcbIUScale, units)
-        return item.GetItemDescription(uProvider, True)
     if isV7() or isV8():
         uProvider = pcbnew.UNITS_PROVIDER(pcbnew.pcbIUScale, units)
         return item.GetItemDescription(uProvider)
-    else:
-        return item.GetSelectMenuText(units)
+    if hasattr(pcbnew, 'pcbIUScale'):  # V9+ including V10+; GetSelectMenuText removed in V10
+        uProvider = pcbnew.UNITS_PROVIDER(pcbnew.pcbIUScale, units)
+        return item.GetItemDescription(uProvider, True)
+    return item.GetSelectMenuText(units)  # pre-V7 fallback only
 
 def getItemFingerprint(item: pcbnew.BOARD_ITEM):
     return (roundCoord(item.GetPosition()[0]), # Round down, since the output does the same
@@ -212,7 +211,9 @@ def runBoardDrc(board: pcbnew.BOARD, strict: bool) -> DrcReport:
 
 def deserializeExclusion(exclusionText: str, board: pcbnew.BOARD) -> DrcExclusion:
     items = exclusionText.split("|")
-    objects = [board.GetItem(pcbnew.KIID(x)) for x in items[3:]]
+    # KiCad 10 renamed BOARD.GetItem() -> BOARD.ResolveItem(); shim supports both
+    _get = (lambda k: board.ResolveItem(k, True)) if hasattr(board, 'ResolveItem') else board.GetItem
+    objects = [_get(pcbnew.KIID(x)) for x in items[3:]]
     objects = [x for x in objects if x is not None]
     return DrcExclusion(items[0],
                         pcbnew.VECTOR2I(int(items[1]), int(items[2])),
@@ -239,7 +240,7 @@ def readBoardDrcExclusions(board: pcbnew.BOARD) -> List[DrcExclusion]:
         exclusions = project["board"]["design_settings"]["drc_exclusions"]
     except KeyError:
         return [] # There are no exclusions
-    if isV9() and len(exclusions) > 0 and isinstance(exclusions[0], list):
+    if len(exclusions) > 0 and isinstance(exclusions[0], list):  # KiCad 9/10+ store exclusions as nested lists
         exclusions = [x[0] for x in exclusions]
     return [deserializeExclusion(e, board) for e in exclusions]
 

--- a/kikit/panelize.py
+++ b/kikit/panelize.py
@@ -1240,7 +1240,9 @@ class Panel:
             exclusions = readBoardDrcExclusions(board)
             for drcE in exclusions:
                 try:
-                    newObjects = [self.board.GetItem(pcbnew.KIID(itemMapping[x.m_Uuid.AsString()])) for x in drcE.objects]
+                    # KiCad 10 renamed BOARD.GetItem() -> BOARD.ResolveItem(); shim supports both
+                    _get = (lambda k: self.board.ResolveItem(k, True)) if hasattr(self.board, 'ResolveItem') else self.board.GetItem
+                    newObjects = [_get(pcbnew.KIID(itemMapping[x.m_Uuid.AsString()])) for x in drcE.objects]
                     assert all(x is not None for x in newObjects)
                     newPosition = doTransformation(drcE.position, rotationAngle, originPoint, translation)
                     self.drcExclusions.append(DrcExclusion(


### PR DESCRIPTION
KiCad 10 introduced several breaking Python API changes that caused KiKit to crash when used with the new version:

1. BOARD.GetItem(KIID) was renamed to BOARD.ResolveItem(KIID, allowNull). Fixed in drc.deserializeExclusion() and panelize.appendBoard() using a hasattr() shim so both old and new KiCad versions are supported.

2. BOARD_ITEM.GetSelectMenuText() was removed in KiCad 10. Fixed in drc.getItemDescription() by restructuring the version checks to use hasattr(pcbnew, 'pcbIUScale') as a proxy for V9+, falling back to GetSelectMenuText only for pre-V7 builds.

3. readBoardDrcExclusions() had an isV9() guard around the nested-list unwrapping for drc_exclusions. Since pcbnewTransition has no isV10(), KiCad 10 fell through and crashed on list.split(). Fixed by relying only on isinstance(exclusions[0], list) to detect the nested format.