### PR TITLE
installMacOS.bash: detect expired cert and stop nuking the source tree

### DIFF
--- a/scripts/installMacOS.bash
+++ b/scripts/installMacOS.bash
@@ -41,6 +41,57 @@ echo "Kicad Python dir: $KICAD_PYTHON" 1>&2
 echo "Python version: $V" 1>&2
 echo "Signing certificate: $CERTIFICATE" 1>&2
 
+# Verify the signing identity exists and is not expired before doing any work.
+# `codesign` reports an expired identity as "no identity found", which is
+# misleading and wastes a lot of debugging time. The keychain may also hold
+# multiple certificates with the same common name (e.g. an old expired one
+# alongside a fresh replacement); accept the install if any of them is still
+# valid, since codesign will pick one of those.
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+security find-certificate -a -c "$CERTIFICATE" -p > "$SCRATCH/certs.pem" 2>/dev/null || true
+if [ ! -s "$SCRATCH/certs.pem" ]; then
+    echo "Error: code-signing certificate '$CERTIFICATE' not found in the keychain." 1>&2
+    echo "Create one via Keychain Access -> Certificate Assistant -> Create a Certificate" 1>&2
+    echo "(Identity Type: Self Signed Root, Certificate Type: Code Signing)," 1>&2
+    echo "or pass an existing identity with -c <name>." 1>&2
+    exit 1
+fi
+awk -v dir="$SCRATCH" '
+    /-----BEGIN CERTIFICATE-----/ {n++; out=sprintf("%s/cert_%d.pem", dir, n)}
+    {print > out}
+' "$SCRATCH/certs.pem"
+NOW_TS=$(date +%s)
+LATEST_END_TS=0
+LATEST_END=""
+for f in "$SCRATCH"/cert_*.pem; do
+    end=$(openssl x509 -in "$f" -noout -enddate 2>/dev/null | sed 's/^notAfter=//')
+    [ -z "$end" ] && continue
+    ts=$(date -j -f "%b %d %H:%M:%S %Y %Z" "$end" +%s 2>/dev/null || echo 0)
+    if [ "$ts" -gt "$LATEST_END_TS" ]; then
+        LATEST_END_TS=$ts
+        LATEST_END=$end
+    fi
+done
+if [ "$LATEST_END_TS" -lt "$NOW_TS" ]; then
+    echo "Error: code-signing certificate '$CERTIFICATE' expired on $LATEST_END." 1>&2
+    echo "Recreate it (Keychain Access -> Certificate Assistant -> Create a Certificate)" 1>&2
+    echo "and consider a long validity period (e.g. 3650 days) to avoid recurrence." 1>&2
+    exit 1
+fi
+
+# Older pip versions (e.g. the 22.0.4 still bundled with KiCad's framework
+# Python) plus legacy setuptools register source-tree files in the install
+# RECORD when running `pip install -e .`. A subsequent reinstall then
+# uninstalls the previous version using that RECORD and deletes the source
+# tree before the new install runs. Uninstall any pre-existing kikit from a
+# scratch directory so any stale relative paths in the RECORD resolve to
+# nothing and cannot harm the source checkout.
+if $KICAD_PYTHON/bin/python3 -m pip show kikit >/dev/null 2>&1; then
+    echo "Removing previous kikit install (from scratch dir to avoid pip 22 RECORD bug)" 1>&2
+    (cd "$SCRATCH" && $KICAD_PYTHON/bin/python3 -m pip uninstall -y kikit)
+fi
+
 if [ $EDITABLE -eq 1 ]; then
     echo "Installing editable version of kikit" 1>&2
     $KICAD_PYTHON/bin/python3 -m pip install -e .


### PR DESCRIPTION
## Summary

Two papercuts that bit me on a second `-e` install today.

- `codesign` reports an expired self-signed identity as `no identity found`, costing a lot of debugging time. Pre-flight check rejects an expired/missing cert with a clear message and a hint to recreate it with a long validity period. Multiple certs sharing the common name are tolerated — the install proceeds if any of them is still valid, since `codesign` will pick one of those.
- KiCad ships pip 22.0.4 with its bundled framework Python. With legacy setuptools, `pip install -e .` registers source-tree files in the install RECORD, so the next install's uninstall step then deletes the working copy before the new install runs. Pre-uninstall any existing kikit from a scratch directory so a bogus RECORD has nothing local to harm.

Both checks are no-ops on a clean first run.

## Test plan

- [x] Cert check: valid identity → proceed.
- [x] Cert check: no matching cert → clear error, exit 1.
- [x] Cert check: all matching certs expired → clear error with the latest end date, exit 1.
- [x] Pre-uninstall block: re-running `sudo ./scripts/installMacOS.bash -e` against an existing editable install on macOS 26.3.1 + KiCad 10.0.1 no longer deletes the source tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)