### PR TITLE
Fix issue with stencil jig generation

### DIFF
--- a/kikit/stencil.py
+++ b/kikit/stencil.py
@@ -172,10 +172,10 @@ def jigMountingHoles(jigFrameSize, origin=toKiCADPoint((0, 0))):
     """ Get list of all mounting holes in a jig of given size """
     w, h = jigFrameSize
     holes = [
-        toKiCADPoint((0, (w + INNER_BORDER) / 2)),
-        toKiCADPoint((0, -(w + INNER_BORDER) / 2)),
-        toKiCADPoint(((h + INNER_BORDER) / 2, 0)),
-        toKiCADPoint((-(h + INNER_BORDER) / 2, 0)),
+        toKiCADPoint(((w + INNER_BORDER) / 2,0 )),
+        toKiCADPoint((-(w + INNER_BORDER) / 2,0 )),
+        toKiCADPoint((0,(h + INNER_BORDER) / 2)),
+        toKiCADPoint((0,-(h + INNER_BORDER) / 2)),
     ]
     return [x + origin for x in holes]
 


### PR DESCRIPTION
Fixes https://github.com/yaqwsx/KiKit/issues/831 where steel stencil jigs were flipping the height and width of the arms. This would cause issues for non rectangular jigs where the PCB was too long for the shorter side.